### PR TITLE
⚡ Bolt: Memoize pure components to prevent re-renders

### DIFF
--- a/frontend/components/MatchGauge.tsx
+++ b/frontend/components/MatchGauge.tsx
@@ -8,11 +8,8 @@ interface MatchGaugeProps {
   size?: number;
 }
 
-const MatchGauge: React.FC<MatchGaugeProps> = ({
-  score,
-  label,
-  size = 200,
-}) => {
+// Optimization: Wrapped MatchGauge in React.memo to prevent unnecessary re-renders when parent components update but the score props remain unchanged.
+const MatchGauge: React.FC<MatchGaugeProps> = React.memo(function MatchGauge({ score, label, size = 200 }: MatchGaugeProps) {
   const [displayScore, setDisplayScore] = useState(0);
   const radius = size * 0.4;
   const strokeWidth = size * 0.08;
@@ -93,6 +90,6 @@ const MatchGauge: React.FC<MatchGaugeProps> = ({
       </div>
     </div>
   );
-};
+});
 
 export default MatchGauge;

--- a/frontend/components/RadarChart.tsx
+++ b/frontend/components/RadarChart.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React from "react";
 import {
   RadarChart as RechartsRadar,
   Radar,
@@ -13,7 +14,8 @@ interface Props {
   title?: string;
 }
 
-export default function RadarChart({ data, title }: Props) {
+// Optimization: Wrapped RadarChart in React.memo to prevent unnecessary re-renders when parent components update but the chart data remains the same.
+const RadarChart = React.memo(function RadarChart({ data, title }: Props) {
   return (
     <div className="glass-card p-8 rounded-[2rem] border-0 bg-white/70 shadow-xl shadow-indigo-500/5 h-full transition-all duration-500 hover:shadow-indigo-500/10">
       {title && (
@@ -62,4 +64,6 @@ export default function RadarChart({ data, title }: Props) {
       </div>
     </div>
   );
-}
+});
+
+export default RadarChart;

--- a/frontend/components/ScoreCard.tsx
+++ b/frontend/components/ScoreCard.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React from "react";
 
 interface Props {
   title: string;
@@ -27,7 +28,8 @@ function getScoreColors(score: number) {
 const R = 54;
 const CIRC = 2 * Math.PI * R;
 
-export default function ScoreCard({ title, score, subtitle }: Props) {
+// Optimization: Wrapped ScoreCard in React.memo to prevent unnecessary re-renders when parent components (like ResumeAnalysisPage) update but the score props remain unchanged.
+const ScoreCard = React.memo(function ScoreCard({ title, score, subtitle }: Props) {
   const { stroke, label } = getScoreColors(score);
   const progress = CIRC - (score / 100) * CIRC;
 
@@ -95,4 +97,6 @@ export default function ScoreCard({ title, score, subtitle }: Props) {
       </div>
     </div>
   );
-}
+});
+
+export default ScoreCard;

--- a/frontend/components/SkillGapList.tsx
+++ b/frontend/components/SkillGapList.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React from "react";
 import { motion } from "framer-motion";
 import { CheckCircle, AlertCircle, Sparkles, TrendingUp } from "lucide-react";
 
@@ -12,7 +13,8 @@ interface Props {
   skillGap: SkillGap;
 }
 
-export default function SkillGapList({ skillGap }: Props) {
+// Optimization: Wrapped SkillGapList in React.memo to prevent unnecessary re-renders when parent components update but the skill gaps data remains unchanged.
+const SkillGapList = React.memo(function SkillGapList({ skillGap }: Props) {
   const container = {
     hidden: { opacity: 0 },
     show: {
@@ -135,4 +137,6 @@ export default function SkillGapList({ skillGap }: Props) {
       </motion.div>
     </div>
   );
-}
+});
+
+export default SkillGapList;


### PR DESCRIPTION
💡 What: Wrapped `ScoreCard`, `RadarChart`, `MatchGauge`, and `SkillGapList` components with `React.memo()`. Added inline documentation for these optimizations.

🎯 Why: These presentational components were unnecessarily re-rendering whenever parent dashboard pages (like Resume Analysis or Github Analysis) updated state, even though their props were strictly the same. This caused wasted CPU cycles during interactive dashboard elements.

📊 Impact: Reduces unnecessary component re-renders during dashboard interactions. The UI thread spends less time reconciling identical DOM trees.

🔬 Measurement: Profiled React render cycles; verify using React Developer Tools Profiler on dashboard pages. See that `ScoreCard` or `MatchGauge` skip renders when parent components (like the Github search input) change state without affecting the score props.

---
*PR created automatically by Jules for task [1000468182816238096](https://jules.google.com/task/1000468182816238096) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized rendering performance of core assessment and visualization components for faster, more responsive application interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->