### PR TITLE
⚡ Bolt: Optimize RSS feed parsing to prevent blocking event loop

### DIFF
--- a/backend/services/job_scraper.py
+++ b/backend/services/job_scraper.py
@@ -132,9 +132,8 @@ async def _fetch_rss_jobs(
 ) -> List[JobListing]:
     # Use feedparser to get jobs from RSS feeds
     try:
-        # feedparser.parse is blocking, but for small feeds it's usually fine.
-        # In a high-perf app, we'd run this in a threadpool.
-        feed = feedparser.parse(url)
+        # feedparser.parse is blocking, so we run it in a threadpool to not block the event loop
+        feed = await asyncio.to_thread(feedparser.parse, url)
     except Exception:
         return []
 


### PR DESCRIPTION
💡 What: Offloaded the synchronous `feedparser.parse` call to a background thread using `asyncio.to_thread`.
🎯 Why: `feedparser.parse` performs blocking network I/O and parsing. When called directly inside an `async def` function in FastAPI, it freezes the entire async event loop until it completes, blocking all other concurrent requests.
📊 Impact: Significantly improves concurrency and responsiveness of the application when fetching jobs via RSS feeds, as the event loop is no longer blocked.
🔬 Measurement: Can be verified by load testing the job scraping endpoint with RSS feeds; you will no longer see event loop stall warnings or blocked concurrent requests.

---
*PR created automatically by Jules for task [10880070239146101033](https://jules.google.com/task/10880070239146101033) started by @SudoAnirudh*