### PR TITLE
⚡ Bolt: Optimize evaluate_session concurrency using asyncio.gather

### DIFF
--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -1,5 +1,6 @@
 import uuid
 import logging
+import asyncio
 from typing import Dict, List
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
@@ -255,21 +256,26 @@ async def evaluate_session(
     by_id = {q["question_id"]: q for q in questions if "question_id" in q}
     feedback_items: List[AnswerFeedback] = []
 
+    evaluation_tasks = []
     for item in payload.answers:
         q = by_id.get(item.question_id)
         if not q:
             continue
-        fb = await evaluate_answer(
-            question_id=item.question_id,
-            question=q["question"],
-            answer=item.answer,
-            category=q.get("category", "technical"),
-            expected_topics=q.get("expected_topics", []) or [],
+        evaluation_tasks.append(
+            evaluate_answer(
+                question_id=item.question_id,
+                question=q["question"],
+                answer=item.answer,
+                category=q.get("category", "technical"),
+                expected_topics=q.get("expected_topics", []) or [],
+            )
         )
-        feedback_items.append(fb)
 
-    if not feedback_items:
+    if not evaluation_tasks:
         raise HTTPException(status_code=400, detail="No valid answers to evaluate.")
+
+    # Execute all answer evaluations concurrently for better performance
+    feedback_items = await asyncio.gather(*evaluation_tasks)
 
     scores_0_10 = [float(f.score) for f in feedback_items if f.score is not None]
     overall_score = (sum(scores_0_10) / len(scores_0_10)) * 10 if scores_0_10 else 0.0


### PR DESCRIPTION
💡 What: Refactored the `evaluate_session` route in `backend/routers/interview.py` to execute independent `evaluate_answer` coroutines concurrently utilizing `asyncio.gather` instead of a sequential loop.

🎯 Why: The previous sequential iteration meant that evaluating a session with N answers took $O(N \cdot T_{\text{LLM}})$ time, causing significant latency for candidates submitting a full interview loop. Since evaluations are independent, they can run parallel.

📊 Impact: Expected performance improvement reduces total evaluation time dramatically, from sum of evaluation latencies down to the maximum single latency, dropping latency by approximately 50-80% for typical sessions containing 5+ answers.

🔬 Measurement: Check the overall execution time of the `evaluate_session` endpoint with an array of ~5 mock answers. Execution times will mirror a single evaluation duration. Unit tests passed locally to guarantee correctness.

---
*PR created automatically by Jules for task [657351496634200748](https://jules.google.com/task/657351496634200748) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the interview evaluation process for improved performance, enabling faster feedback generation on submitted answers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->