### PR TITLE
🎨 Palette: Improve keyboard accessibility and screen reader support in CoverLetterModal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-04-05 - Keyboard focus styles for standard buttons
+**Learning:** Standard `<button>` tags in this app do not inherit the default focus styles provided by the global `Button` component. This means they remain visually invisible during keyboard navigation.
+**Action:** Always manually add `focus-visible` utility classes (e.g. `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[theme_color]`) to standard `<button>` tags to ensure proper keyboard accessibility.

--- a/frontend/components/CoverLetterModal.tsx
+++ b/frontend/components/CoverLetterModal.tsx
@@ -116,7 +116,7 @@ export default function CoverLetterModal({
                   <button
                     key={t}
                     onClick={() => setTone(t)}
-                    className={`w-full px-4 py-3 rounded-xl border text-xs font-bold transition-all text-left flex items-center justify-between ${
+                    className={`w-full px-4 py-3 rounded-xl border text-xs font-bold transition-all text-left flex items-center justify-between focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7C9ADD] focus-visible:ring-offset-1 ${
                       tone === t
                         ? "bg-white border-[#7C9ADD] text-[#7C9ADD] shadow-sm scale-[1.02]"
                         : "bg-transparent border-slate-200 text-slate-500 hover:border-slate-300"
@@ -151,7 +151,8 @@ export default function CoverLetterModal({
         <div className="flex-1 flex flex-col relative bg-white">
           <button
             onClick={onClose}
-            className="absolute right-6 top-6 p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-full transition-all z-10"
+            aria-label="Close modal"
+            className="absolute right-6 top-6 p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-full transition-all z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
           >
             <X size={20} />
           </button>
@@ -171,7 +172,8 @@ export default function CoverLetterModal({
                   <div className="flex items-center gap-2">
                     <button
                       onClick={handleCopy}
-                      className="p-2 text-slate-400 hover:text-[#7C9ADD] hover:bg-[#7C9ADD]/5 rounded-lg transition-all"
+                      aria-label="Copy to clipboard"
+                      className="p-2 text-slate-400 hover:text-[#7C9ADD] hover:bg-[#7C9ADD]/5 rounded-lg transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7C9ADD] focus-visible:ring-offset-1"
                       title="Copy to Clipboard"
                     >
                       {copied ? (


### PR DESCRIPTION
This PR introduces a targeted UX and accessibility enhancement to the `CoverLetterModal` component.

### 💡 What:
- Added explicit `aria-label` attributes to icon-only buttons (Close and Copy).
- Implemented Tailwind `focus-visible` utility classes (e.g., `focus-visible:outline-none focus-visible:ring-2`) on standard `<button>` tags within the modal.

### 🎯 Why:
- Screen reader users were previously unable to determine the function of the Close and Copy buttons because they only contained icons or a `title` attribute.
- Keyboard users (navigating via Tab) had no visual indication of which button was currently focused, making navigation difficult. This occurred because standard HTML `<button>` tags do not automatically inherit the custom focus states defined in the global `Button` component.

### ♿ Accessibility:
- Improves WCAG compliance for non-text content (by adding aria-labels).
- Improves WCAG compliance for focus visibility (by adding clear visual indicators on focus).

### 📓 Learnings Documented:
- Logged the learning in `.Jules/palette.md` that standard `<button>` tags in this application require manual application of `focus-visible` classes to ensure keyboard accessibility.

---
*PR created automatically by Jules for task [5872564211165552813](https://jules.google.com/task/5872564211165552813) started by @SudoAnirudh*