### PR TITLE
🎨 Palette: Improve Keyboard and Screen Reader Accessibility in ResumeEditor

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-07 - [Added Accessibility Labels to Editor]
+**Learning:** Native `<button>` elements in this specific codebase, particularly in custom toolbars like the Tiptap editor in `ResumeEditor.tsx`, don't inherit the `focus-visible` styles or `type` constraints defined in the global custom `Button` component. It's critical to manually specify `type="button"` to avoid implicit form submission, and attach Tailwind utilities like `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7C9ADD]/50` along with `aria-label` attributes to ensure they are accessible.
+**Action:** When adding or auditing standalone `<button>` tags outside the `ui/button.tsx` file, always double check for `type`, `aria-label`, and `focus-visible` classes.

--- a/frontend/components/ResumeEditor.tsx
+++ b/frontend/components/ResumeEditor.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 
 const toolbarBtn =
-  "p-2 rounded-xl transition-all disabled:opacity-50 disabled:pointer-events-none hover:bg-[#7C9ADD]/10 text-[#4A5568]";
+  "p-2 rounded-xl transition-all disabled:opacity-50 disabled:pointer-events-none hover:bg-[#7C9ADD]/10 text-[#4A5568] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7C9ADD]/50";
 
 const MenuBar = ({
   editor,
@@ -57,18 +57,22 @@ const MenuBar = ({
     <div className="flex flex-wrap items-center gap-1.5 p-3 sticky top-0 z-10 border-b border-white/60 bg-white/60 backdrop-blur-xl">
       <div className="flex items-center gap-1 pr-2 mr-1 border-r border-[#7C9ADD]/10">
         <button
+          type="button"
           onClick={() => editor.chain().focus().undo().run()}
           disabled={!editor.can().chain().focus().undo().run()}
           className={`${toolbarBtn} ${idleClass}`}
           title="Undo"
+          aria-label="Undo"
         >
           <Undo className="w-4 h-4" />
         </button>
         <button
+          type="button"
           onClick={() => editor.chain().focus().redo().run()}
           disabled={!editor.can().chain().focus().redo().run()}
           className={`${toolbarBtn} ${idleClass}`}
           title="Redo"
+          aria-label="Redo"
         >
           <Redo className="w-4 h-4" />
         </button>
@@ -76,26 +80,32 @@ const MenuBar = ({
 
       <div className="flex items-center gap-1.5 pr-2 mr-1 border-r border-[#7C9ADD]/10">
         <button
+          type="button"
           onClick={() => editor.chain().focus().toggleBold().run()}
           disabled={!editor.can().chain().focus().toggleBold().run()}
           className={`${toolbarBtn} ${editor.isActive("bold") ? "bg-[#7C9ADD]/10 text-[#7C9ADD] shadow-sm" : "text-[#718096] hover:text-[#7C9ADD]"}`}
           title="Bold"
+          aria-label="Bold"
         >
           <Bold className="w-4 h-4" />
         </button>
         <button
+          type="button"
           onClick={() => editor.chain().focus().toggleItalic().run()}
           disabled={!editor.can().chain().focus().toggleItalic().run()}
           className={`${toolbarBtn} ${editor.isActive("italic") ? activeClass : idleClass}`}
           title="Italic"
+          aria-label="Italic"
         >
           <Italic className="w-4 h-4" />
         </button>
         <button
+          type="button"
           onClick={() => editor.chain().focus().toggleUnderline().run()}
           disabled={!editor.can().chain().focus().toggleUnderline().run()}
           className={`${toolbarBtn} ${editor.isActive("underline") ? activeClass : idleClass}`}
           title="Underline"
+          aria-label="Underline"
         >
           <UnderlineIcon className="w-4 h-4" />
         </button>
@@ -103,20 +113,24 @@ const MenuBar = ({
 
       <div className="flex items-center gap-1.5 pr-2 mr-1 border-r border-[#7C9ADD]/10">
         <button
+          type="button"
           onClick={() =>
             editor.chain().focus().toggleHeading({ level: 1 }).run()
           }
           className={`${toolbarBtn} ${editor.isActive("heading", { level: 1 }) ? activeClass : idleClass}`}
           title="Heading 1"
+          aria-label="Heading 1"
         >
           <Heading1 className="w-4 h-4" />
         </button>
         <button
+          type="button"
           onClick={() =>
             editor.chain().focus().toggleHeading({ level: 2 }).run()
           }
           className={`${toolbarBtn} ${editor.isActive("heading", { level: 2 }) ? activeClass : idleClass}`}
           title="Heading 2"
+          aria-label="Heading 2"
         >
           <Heading2 className="w-4 h-4" />
         </button>
@@ -124,16 +138,20 @@ const MenuBar = ({
 
       <div className="flex items-center gap-1.5 pr-2 mr-1 border-r border-[#7C9ADD]/10">
         <button
+          type="button"
           onClick={() => editor.chain().focus().toggleBulletList().run()}
           className={`${toolbarBtn} ${editor.isActive("bulletList") ? activeClass : idleClass}`}
           title="Bullet List"
+          aria-label="Bullet List"
         >
           <List className="w-4 h-4" />
         </button>
         <button
+          type="button"
           onClick={() => editor.chain().focus().toggleOrderedList().run()}
           className={`${toolbarBtn} ${editor.isActive("orderedList") ? activeClass : idleClass}`}
           title="Numbered List"
+          aria-label="Numbered List"
         >
           <ListOrdered className="w-4 h-4" />
         </button>
@@ -141,30 +159,38 @@ const MenuBar = ({
 
       <div className="flex items-center gap-1.5 pr-2 mr-1 border-r border-[#7C9ADD]/10">
         <button
+          type="button"
           onClick={() => editor.chain().focus().setTextAlign("left").run()}
           className={`${toolbarBtn} ${editor.isActive({ textAlign: "left" }) ? activeClass : idleClass}`}
           title="Align Left"
+          aria-label="Align Left"
         >
           <AlignLeft className="w-4 h-4" />
         </button>
         <button
+          type="button"
           onClick={() => editor.chain().focus().setTextAlign("center").run()}
           className={`${toolbarBtn} ${editor.isActive({ textAlign: "center" }) ? activeClass : idleClass}`}
           title="Align Center"
+          aria-label="Align Center"
         >
           <AlignCenter className="w-4 h-4" />
         </button>
         <button
+          type="button"
           onClick={() => editor.chain().focus().setTextAlign("right").run()}
           className={`${toolbarBtn} ${editor.isActive({ textAlign: "right" }) ? activeClass : idleClass}`}
           title="Align Right"
+          aria-label="Align Right"
         >
           <AlignRight className="w-4 h-4" />
         </button>
         <button
+          type="button"
           onClick={() => editor.chain().focus().setTextAlign("justify").run()}
           className={`${toolbarBtn} ${editor.isActive({ textAlign: "justify" }) ? activeClass : idleClass}`}
           title="Justify"
+          aria-label="Justify"
         >
           <AlignJustify className="w-4 h-4" />
         </button>
@@ -172,9 +198,11 @@ const MenuBar = ({
 
       <div className="flex items-center gap-1.5">
         <button
+          type="button"
           onClick={setLink}
           className={`${toolbarBtn} ${editor.isActive("link") ? activeClass : idleClass}`}
           title="Add Link"
+          aria-label="Add Link"
         >
           <LinkIcon className="w-4 h-4" />
         </button>


### PR DESCRIPTION
This pull request implements UX and accessibility improvements in the `ResumeEditor` component.

**What:** 
- Added standard `aria-label` properties to all icon-only buttons in the Tiptap toolbar.
- Added explicit `type="button"` attributes to the toolbar buttons.
- Appended `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7C9ADD]/50` to the shared `toolbarBtn` class.

**Why:** 
- Without `aria-label`, screen readers cannot announce the purpose of icon-only buttons to visually impaired users.
- Without `type="button"`, `<button>` tags within a `<form>` context will default to `type="submit"`, potentially causing unintended page reloads.
- Without explicit `focus-visible` styles, keyboard users (tabbing through the interface) have no visual indicator of which button currently has focus.

**Accessibility:**
This change makes the entire `ResumeEditor` rich-text toolbar fully keyboard navigable and screen reader friendly, adhering to WCAG guidelines.

---
*PR created automatically by Jules for task [6243830576507296928](https://jules.google.com/task/6243830576507296928) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved keyboard focus styling on editor toolbar buttons with visible ring indicators for better keyboard navigation visibility.

* **Documentation**
  * Added accessibility guidelines for native button elements, documenting best practices for proper attributes and descriptive labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->