### PR TITLE
⚡ Bolt: Parallelize evaluate_session with asyncio.gather

### DIFF
--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -1,4 +1,5 @@
 import uuid
+import asyncio
 import logging
 from typing import Dict, List
 from fastapi import APIRouter, Depends, HTTPException
@@ -255,18 +256,25 @@ async def evaluate_session(
     by_id = {q["question_id"]: q for q in questions if "question_id" in q}
     feedback_items: List[AnswerFeedback] = []
 
+    # ⚡ Bolt: Parallelize independent I/O-bound LLM evaluations to reduce latency
+    # What: Uses asyncio.gather to run answer evaluations concurrently.
+    # Why: evaluate_answer makes external network requests. Running them sequentially takes O(N) time.
+    # Impact: Reduces total evaluation time from ~N*t to ~max(t), significantly speeding up the final result screen.
+    tasks = []
     for item in payload.answers:
         q = by_id.get(item.question_id)
         if not q:
             continue
-        fb = await evaluate_answer(
+        tasks.append(evaluate_answer(
             question_id=item.question_id,
             question=q["question"],
             answer=item.answer,
             category=q.get("category", "technical"),
             expected_topics=q.get("expected_topics", []) or [],
-        )
-        feedback_items.append(fb)
+        ))
+
+    if tasks:
+        feedback_items.extend(await asyncio.gather(*tasks))
 
     if not feedback_items:
         raise HTTPException(status_code=400, detail="No valid answers to evaluate.")


### PR DESCRIPTION
💡 What: Use `asyncio.gather` instead of sequential await loops in `evaluate_session`.
🎯 Why: `evaluate_answer` performs external network requests. Running them sequentially caused O(N) execution time, slowing down the result screen processing.
📊 Impact: Expected to reduce the total interview evaluation time significantly.
🔬 Measurement: Verify via backend API testing and observing response times compared to the previous sequential approach.

---
*PR created automatically by Jules for task [5986075062591903594](https://jules.google.com/task/5986075062591903594) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Interview evaluation feedback is now processed concurrently, allowing multiple items to be evaluated in parallel rather than sequentially.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->