### PR TITLE
🎨 Palette: Add ARIA labels and focus states to icon-only buttons

### DIFF
--- a/frontend/app/dashboard/account/page.tsx
+++ b/frontend/app/dashboard/account/page.tsx
@@ -157,7 +157,10 @@ export default function AccountPage() {
             <div className="flex flex-col items-center text-center space-y-4 relative z-10">
               <div className="h-28 w-28 rounded-full bg-linear-to-tr from-indigo-500 to-violet-500 flex items-center justify-center text-white shadow-xl border-4 border-white mb-2 relative group/avatar">
                 <User size={56} strokeWidth={1} />
-                <button className="absolute bottom-0 right-0 p-2 bg-white rounded-full shadow-lg border border-slate-100 text-indigo-500 hover:scale-110 transition-transform">
+                <button
+                  aria-label="Edit public profile settings"
+                  className="absolute bottom-0 right-0 p-2 bg-white rounded-full shadow-lg border border-slate-100 text-indigo-500 hover:scale-110 transition-transform focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+                >
                   <Globe size={14} />
                 </button>
               </div>

--- a/frontend/components/CoverLetterModal.tsx
+++ b/frontend/components/CoverLetterModal.tsx
@@ -151,7 +151,8 @@ export default function CoverLetterModal({
         <div className="flex-1 flex flex-col relative bg-white">
           <button
             onClick={onClose}
-            className="absolute right-6 top-6 p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-full transition-all z-10"
+            aria-label="Close modal"
+            className="absolute right-6 top-6 p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-full transition-all z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
           >
             <X size={20} />
           </button>
@@ -171,7 +172,8 @@ export default function CoverLetterModal({
                   <div className="flex items-center gap-2">
                     <button
                       onClick={handleCopy}
-                      className="p-2 text-slate-400 hover:text-[#7C9ADD] hover:bg-[#7C9ADD]/5 rounded-lg transition-all"
+                      aria-label="Copy to Clipboard"
+                      className="p-2 text-slate-400 hover:text-[#7C9ADD] hover:bg-[#7C9ADD]/5 rounded-lg transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7C9ADD]"
                       title="Copy to Clipboard"
                     >
                       {copied ? (

--- a/frontend/components/OutreachModal.tsx
+++ b/frontend/components/OutreachModal.tsx
@@ -103,7 +103,8 @@ export default function OutreachModal({
           </div>
           <button
             onClick={onClose}
-            className="w-12 h-12 rounded-2xl hover:bg-[#F1F5F9] flex items-center justify-center text-[#A0AEC0] transition-colors"
+            aria-label="Close modal"
+            className="w-12 h-12 rounded-2xl hover:bg-[#F1F5F9] flex items-center justify-center text-[#A0AEC0] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
           >
             <X size={24} />
           </button>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes and `focus-visible` ring styles to several icon-only `<button>`s.
🎯 Why: To improve keyboard navigation and screen-reader accessibility for previously silent interactive elements without accessible names.
♿ Accessibility: Ensures that screen reader users know what actions are being performed (closing modals, copying to clipboard, editing profile settings) and gives visual focus rings for keyboard users.

---
*PR created automatically by Jules for task [2837659147386151518](https://jules.google.com/task/2837659147386151518) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation and accessibility support for profile settings, modal controls, and copy actions with enhanced focus indicators and screen reader labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->