### PR TITLE
⚡ Bolt: Eliminate N+1 Embedding API Calls in Job Matching

### DIFF
--- a/backend/routers/job_match.py
+++ b/backend/routers/job_match.py
@@ -6,7 +6,7 @@ from dependencies import get_current_user, get_supabase_admin
 from services.jd_matcher import match_job_description
 from services.job_scraper import scrape_jobs
 from services.resume_parser import parse_resume
-from services.embedding_engine import compare_texts
+from services.embedding_engine import compare_texts, get_embedding
 from services.job_suggester import generate_job_suggestions
 from models.analysis import (
     JobMatchRequest,
@@ -175,10 +175,13 @@ async def scrape_jobs_for_fields(
     if r.data:
         resume_text = r.data[0]["raw_text"]
         
+        # Precompute the resume embedding once outside the loop to prevent N+1 computations
+        resume_emb = await get_embedding(resume_text)
+
         # 3. Quick Match injection (Semantic Only for speed during browse)
         async def _score_job(job):
             # Job description snippet is used for speed
-            score = await compare_texts(resume_text, job.description_snippet)
+            score = await compare_texts(resume_text, job.description_snippet, precomputed_emb_a=resume_emb)
             job.match_score = round(score * 100, 1)
             # Generate a unique ID if missing
             if not job.id:

--- a/backend/services/embedding_engine.py
+++ b/backend/services/embedding_engine.py
@@ -103,13 +103,13 @@ def cosine_similarity(vec_a: List[float], vec_b: List[float]) -> float:
         return 0.0
     return float(np.dot(a, b) / denom)
 
-async def compare_texts(text_a: str, text_b: str) -> float:
+async def compare_texts(text_a: str, text_b: str, precomputed_emb_a: Optional[List[float]] = None) -> float:
     """
     Compute semantic similarity between two texts.
     Returns a float in [0, 1]. Falls back to Jaccard similarity if needed.
     """
     # Prefer vector comparison (API-first)
-    emb_a = await get_embedding(text_a)
+    emb_a = precomputed_emb_a if precomputed_emb_a is not None else await get_embedding(text_a)
     emb_b = await get_embedding(text_b)
     
     if emb_a is not None and emb_b is not None:

--- a/backend/services/outreach_service.py
+++ b/backend/services/outreach_service.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Optional, Dict, Any
+from typing import Optional, Any
 from services.nvidia_client import invoke_nvidia_llm
 from models.analysis import OutreachDraftsResponse
 

--- a/backend/services/roadmap_engine.py
+++ b/backend/services/roadmap_engine.py
@@ -1,9 +1,8 @@
 import json
 import logging
-from typing import List, Optional
-from models.roadmap import Roadmap, RoadmapSkill, Resource
+from typing import Optional
+from models.roadmap import Roadmap
 from services.skill_gap import detect_skill_gap
-from services.github_analyzer import analyze_github_profile
 from services.nvidia_client import invoke_nvidia_llm
 from services.groq_client import invoke_groq_llm
 from services.cache_manager import cache_manager


### PR DESCRIPTION
💡 **What:** Added an optional parameter `precomputed_emb_a` to the `compare_texts` function in the embedding engine and passed the user's precomputed resume embedding from the loop in the `scrape-jobs` endpoint.
🎯 **Why:** To eliminate an N+1 performance bottleneck. Previously, mapping over N jobs triggered N identical calls to `get_embedding` for the exact same `resume_text`, flooding the NVIDIA API or sentence-transformer fallback and causing significant latency. 
📊 **Impact:** Reduces `get_embedding` API calls for the user's resume from N to 1 during the `scrape-jobs` quick match phase, substantially decreasing overall route latency.
🔬 **Measurement:** Running the backend tests and confirming that performance scales correctly regardless of the number of jobs scraped.

---
*PR created automatically by Jules for task [10384152764375608574](https://jules.google.com/task/10384152764375608574) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized job matching to reduce redundant computation operations.

* **Chores**
  * Cleaned up unused imports across backend services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->