### PR TITLE
🎨 Palette: Add ARIA labels and focus styles to modal icon buttons

### DIFF
--- a/frontend/components/CoverLetterModal.tsx
+++ b/frontend/components/CoverLetterModal.tsx
@@ -151,7 +151,8 @@ export default function CoverLetterModal({
         <div className="flex-1 flex flex-col relative bg-white">
           <button
             onClick={onClose}
-            className="absolute right-6 top-6 p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-full transition-all z-10"
+            aria-label="Close modal"
+            className="absolute right-6 top-6 p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-full transition-all z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7C9ADD]"
           >
             <X size={20} />
           </button>
@@ -171,8 +172,9 @@ export default function CoverLetterModal({
                   <div className="flex items-center gap-2">
                     <button
                       onClick={handleCopy}
-                      className="p-2 text-slate-400 hover:text-[#7C9ADD] hover:bg-[#7C9ADD]/5 rounded-lg transition-all"
+                      className="p-2 text-slate-400 hover:text-[#7C9ADD] hover:bg-[#7C9ADD]/5 rounded-lg transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7C9ADD]"
                       title="Copy to Clipboard"
+                      aria-label={copied ? "Copied to clipboard" : "Copy to clipboard"}
                     >
                       {copied ? (
                         <Check size={18} className="text-emerald-500" />

--- a/frontend/components/OutreachModal.tsx
+++ b/frontend/components/OutreachModal.tsx
@@ -103,7 +103,8 @@ export default function OutreachModal({
           </div>
           <button
             onClick={onClose}
-            className="w-12 h-12 rounded-2xl hover:bg-[#F1F5F9] flex items-center justify-center text-[#A0AEC0] transition-colors"
+            aria-label="Close modal"
+            className="w-12 h-12 rounded-2xl hover:bg-[#F1F5F9] flex items-center justify-center text-[#A0AEC0] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7C9ADD]"
           >
             <X size={24} />
           </button>


### PR DESCRIPTION
This PR implements a small micro-UX accessibility improvement.

**What:** Added `aria-label` and `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7C9ADD]` to icon-only buttons (Close and Copy) in `CoverLetterModal.tsx` and `OutreachModal.tsx`.
**Why:** Icon-only buttons without text labels are inaccessible to screen readers. Standard HTML buttons in this project lack the global focus styles provided by the custom `<Button>` component, meaning keyboard-only users could not see which element had focus.
**Accessibility:** Improved screen reader support with context-aware labels (e.g., changing from "Copy to clipboard" to "Copied to clipboard") and enhanced keyboard navigation visibility with explicit focus rings. Documented learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [7049409434115384939](https://jules.google.com/task/7049409434115384939) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Modal buttons now display visible focus indicators when navigating via keyboard
  * Updated button labels in modals for enhanced accessibility support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->