### PR TITLE
⚡ Bolt: Pre-compile regex in job scraper

### DIFF
--- a/backend/services/job_scraper.py
+++ b/backend/services/job_scraper.py
@@ -9,12 +9,18 @@ from models.analysis import JobListing
 
 logger = logging.getLogger("hirenix.job_scraper")
 
+# ⚡ Bolt: Pre-compile regex for HTML stripping to reduce compilation overhead
+# What: Pre-compile the _HTML_TAG_PATTERN and _WHITESPACE_PATTERN at the module level.
+# Why: _strip_html is called repeatedly in scraping loops. Without pre-compiling, re.sub dynamically checks the regex cache or compiles the pattern on every call, increasing CPU overhead.
+# Impact: Reduces CPU time spent on repetitive regex initialization, speeding up job scraping and processing large JSON payloads.
+_HTML_TAG_PATTERN = re.compile(r"<[^>]+>")
+_WHITESPACE_PATTERN = re.compile(r"\s+")
 
 def _strip_html(text: str) -> str:
     if not text:
         return ""
-    text = re.sub(r"<[^>]+>", " ", text)
-    text = re.sub(r"\s+", " ", text)
+    text = _HTML_TAG_PATTERN.sub(" ", text)
+    text = _WHITESPACE_PATTERN.sub(" ", text)
     return text.strip()
 
 


### PR DESCRIPTION
💡 **What**: Pre-compiled `_HTML_TAG_PATTERN` and `_WHITESPACE_PATTERN` at the module level in `backend/services/job_scraper.py`.
🎯 **Why**: The `_strip_html` function is executed inside large scraping loops. Relying on `re.sub()` to process string patterns introduces unnecessary cache lookups or compilation overhead for each string parsed.
📊 **Impact**: Reduces CPU overhead during JSON scraping operations. Avoids redundant regex processing when traversing large job lists, allowing faster payload processing.
🔬 **Measurement**: Verified by backend test suite `cd backend && PYTHONPATH=. python3 -m unittest` ensuring stripping outputs remain entirely correct without regression.

---
*PR created automatically by Jules for task [12942572489481848752](https://jules.google.com/task/12942572489481848752) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized backend job scraper with improved regex handling for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->