### PR TITLE
🎨 Palette: Improve accessibility of modal close buttons

### DIFF
--- a/frontend/components/CoverLetterModal.tsx
+++ b/frontend/components/CoverLetterModal.tsx
@@ -151,7 +151,8 @@ export default function CoverLetterModal({
         <div className="flex-1 flex flex-col relative bg-white">
           <button
             onClick={onClose}
-            className="absolute right-6 top-6 p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-full transition-all z-10"
+            aria-label="Close modal"
+            className="absolute right-6 top-6 p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-full transition-all z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
           >
             <X size={20} />
           </button>

--- a/frontend/components/OutreachModal.tsx
+++ b/frontend/components/OutreachModal.tsx
@@ -103,7 +103,8 @@ export default function OutreachModal({
           </div>
           <button
             onClick={onClose}
-            className="w-12 h-12 rounded-2xl hover:bg-[#F1F5F9] flex items-center justify-center text-[#A0AEC0] transition-colors"
+            aria-label="Close modal"
+            className="w-12 h-12 rounded-2xl hover:bg-[#F1F5F9] flex items-center justify-center text-[#A0AEC0] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
           >
             <X size={24} />
           </button>

--- a/frontend/components/dashboard/AddApplicationModal.tsx
+++ b/frontend/components/dashboard/AddApplicationModal.tsx
@@ -84,7 +84,8 @@ export default function AddApplicationModal({
               <div className="relative p-8">
                 <button
                   onClick={onClose}
-                  className="absolute top-6 right-6 p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-400 transition-colors"
+                  aria-label="Close modal"
+                  className="absolute top-6 right-6 p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-400 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50"
                 >
                   <X size={20} />
                 </button>


### PR DESCRIPTION
💡 **What**: Added `aria-label` and `focus-visible` Tailwind classes to the "Close" icon buttons across three main application modals (`AddApplicationModal.tsx`, `CoverLetterModal.tsx`, and `OutreachModal.tsx`).

🎯 **Why**: To improve keyboard navigation and screen-reader accessibility. These raw HTML buttons were previously lacking semantic labels and clear visual indicators when focused via keyboard navigation, leading to a poor experience for users utilizing assistive technologies.

📸 **Before/After**: See the included Playwright verification recording. 

♿ **Accessibility**:
- Added `aria-label="Close modal"` to all modal close buttons.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400` (or `indigo-500/50`) to visually indicate focus state for keyboard users without affecting default mouse click styles.

---
*PR created automatically by Jules for task [8985869112607334719](https://jules.google.com/task/8985869112607334719) started by @SudoAnirudh*