### PR TITLE
⚡ Bolt: Batch insert resume sections to avoid N+1 queries

### DIFF
--- a/backend/routers/resume.py
+++ b/backend/routers/resume.py
@@ -66,15 +66,24 @@ async def upload_resume(
         }
     ).execute()
 
-    for section in sections:
-        db.table("resume_sections").insert(
+    # ⚡ Bolt: Batch insert resume sections to avoid N+1 queries
+    # What: Build a list of section dicts and execute a single .insert() call.
+    # Why: Previously, `.insert().execute()` was called inside a loop, making
+    #      multiple sequential synchronous network requests to Supabase and
+    #      blocking the async event loop.
+    # Impact: Reduces database calls from N (number of sections) to 1,
+    #         significantly improving upload/parsing latency.
+    if sections:
+        section_records = [
             {
                 "id": str(uuid.uuid4()),
                 "resume_id": resume_id,
                 "section_type": section.section_type,
                 "content": section.content,
             }
-        ).execute()
+            for section in sections
+        ]
+        db.table("resume_sections").insert(section_records).execute()
 
     return ResumeUploadResponse(
         resume_id=resume_id,


### PR DESCRIPTION
💡 What: Refactored the `upload_resume` endpoint in `backend/routers/resume.py` to batch insert resume sections into Supabase instead of executing `.insert().execute()` inside a `for` loop.
🎯 Why: Previously, the sequential `.insert().execute()` calls caused an N+1 query problem, making multiple synchronous network requests that blocked the async event loop.
📊 Impact: Reduces database network calls from N (number of sections parsed) to exactly 1, significantly improving the upload and parsing latency for resumes.
🔬 Measurement: Verify by uploading a multi-section PDF resume and measuring the response time; the elapsed time should be demonstrably lower.

---
*PR created automatically by Jules for task [4030019534341470653](https://jules.google.com/task/4030019534341470653) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resume section storage mechanism in the upload process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->