### PR TITLE
🎨 Palette: Accessibility - Add ARIA labels to icon-only close buttons

### DIFF
--- a/frontend/components/CoverLetterModal.tsx
+++ b/frontend/components/CoverLetterModal.tsx
@@ -151,6 +151,7 @@ export default function CoverLetterModal({
         <div className="flex-1 flex flex-col relative bg-white">
           <button
             onClick={onClose}
+            aria-label="Close modal"
             className="absolute right-6 top-6 p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-full transition-all z-10"
           >
             <X size={20} />

--- a/frontend/components/OutreachModal.tsx
+++ b/frontend/components/OutreachModal.tsx
@@ -103,6 +103,7 @@ export default function OutreachModal({
           </div>
           <button
             onClick={onClose}
+            aria-label="Close modal"
             className="w-12 h-12 rounded-2xl hover:bg-[#F1F5F9] flex items-center justify-center text-[#A0AEC0] transition-colors"
           >
             <X size={24} />

--- a/frontend/components/dashboard/AddApplicationModal.tsx
+++ b/frontend/components/dashboard/AddApplicationModal.tsx
@@ -84,6 +84,7 @@ export default function AddApplicationModal({
               <div className="relative p-8">
                 <button
                   onClick={onClose}
+                  aria-label="Close modal"
                   className="absolute top-6 right-6 p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-400 transition-colors"
                 >
                   <X size={20} />


### PR DESCRIPTION
*   💡 **What**: Added `aria-label="Close modal"` to the icon-only "close" buttons (`<X />`) in three different modal components.
*   🎯 **Why**: Previously, these buttons only had an icon, meaning screen readers would announce them simply as "button" with no context of their function. This UX enhancement ensures users with screen readers can easily identify and use the close functionality.
*   ♿ **Accessibility**: Significant improvement for screen-reader users, providing context to previously unlabeled, icon-only buttons.
*   📝 **Journal**: Added a learning entry to `.jules/palette.md` instructing the addition of `aria-label` to icon-only buttons.

---
*PR created automatically by Jules for task [15119724612954751068](https://jules.google.com/task/15119724612954751068) started by @SudoAnirudh*