### PR TITLE
⚡ Bolt: Batch insert resume sections to avoid N+1 queries

### DIFF
--- a/backend/routers/resume.py
+++ b/backend/routers/resume.py
@@ -66,15 +66,21 @@ async def upload_resume(
         }
     ).execute()
 
-    for section in sections:
-        db.table("resume_sections").insert(
+    # ⚡ Bolt: Batch insert resume sections to avoid N+1 queries
+    # What: Replaced a loop of individual `.insert().execute()` calls with a single bulk insert list.
+    # Why: Executing queries inside a loop causes multiple synchronous network roundtrips to Supabase, slowing down resume upload.
+    # Impact: Reduces database calls from O(N) to O(1), improving upload latency by roughly N * ~50ms.
+    if sections:
+        sections_data = [
             {
                 "id": str(uuid.uuid4()),
                 "resume_id": resume_id,
                 "section_type": section.section_type,
                 "content": section.content,
             }
-        ).execute()
+            for section in sections
+        ]
+        db.table("resume_sections").insert(sections_data).execute()
 
     return ResumeUploadResponse(
         resume_id=resume_id,


### PR DESCRIPTION
💡 **What**: Replaced the sequential looping of `.insert().execute()` when storing parsed `resume_sections` with a single bulk `.insert(array_of_dicts).execute()`.
🎯 **Why**: Supabase SDK `.execute()` calls perform synchronous network requests. Looping over 10-20 extracted resume sections meant 10-20 separate database round trips, creating a linear N+1 performance bottleneck that significantly slowed down resume upload.
📊 **Impact**: Reduces database insert calls from O(N) to O(1), cutting network roundtrips and significantly speeding up the `/upload-resume` response time.
🔬 **Measurement**: Verified using a mock performance test comparing the insert call counts. Total `insert()` triggers for parsing a 50-section document dropped from 51 to 2.

---
*PR created automatically by Jules for task [1018035730493060011](https://jules.google.com/task/1018035730493060011) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized resume section database operations by consolidating multiple insert calls into a single batched insert, reducing database overhead and improving system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->