### PR TITLE
🎨 Palette: Add accessible keyboard focus and ARIA labels to hover-revealed buttons

### DIFF
--- a/frontend/components/github/ImpactStoryteller.tsx
+++ b/frontend/components/github/ImpactStoryteller.tsx
@@ -95,7 +95,9 @@ export default function ImpactStoryteller({ repos }: ImpactStorytellerProps) {
                     </p>
                     <button
                       onClick={() => copyToClipboard(point, globalIdx)}
-                      className="absolute right-0 top-0 p-2 rounded-lg bg-white dark:bg-slate-900 border border-slate-100 dark:border-slate-800 opacity-0 group-hover/point:opacity-100 items-center justify-center transition-all hover:scale-105"
+                      aria-label="Copy impact statement"
+                      title="Copy impact statement"
+                      className="absolute right-0 top-0 p-2 rounded-lg bg-white dark:bg-slate-900 border border-slate-100 dark:border-slate-800 opacity-0 group-hover/point:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:outline-none items-center justify-center transition-all hover:scale-105"
                     >
                       {copiedIndex === globalIdx ? (
                         <Check size={14} className="text-emerald-500" />


### PR DESCRIPTION
🎨 **Palette: Add accessible keyboard focus and ARIA labels to hover-revealed buttons**

💡 **What:** Added `aria-label` and `title` to the icon-only copy button in the `ImpactStoryteller` component. I also added `focus-visible` Tailwind utilities (`focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:outline-none`) to ensure the button is visible and highlighted when navigating via keyboard. Finally, I documented this accessible pattern in `.jules/palette.md`.
🎯 **Why:** Icon buttons that rely purely on a container's hover state to become visible (`opacity-0 group-hover:opacity-100`) break accessibility for keyboard users, who tab blindly onto invisible elements, and screen reader users, who lack a semantic label for the action. 
♿ **Accessibility:** Fixes WCAG criteria regarding Name, Role, Value (by adding an accessible name) and Focus Visible (by adding focus state styling to an otherwise invisible element).

---
*PR created automatically by Jules for task [12197730527468098788](https://jules.google.com/task/12197730527468098788) started by @SudoAnirudh*