### PR TITLE
🎨 Palette: Improve keyboard accessibility and screen reader support for ImpactStoryteller copy button

### DIFF
--- a/frontend/components/github/ImpactStoryteller.tsx
+++ b/frontend/components/github/ImpactStoryteller.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { Copy, Check, Sparkles, BookOpen } from "lucide-react";
 import { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
 import { toast } from "sonner";
 
 interface Repo {
@@ -95,7 +94,9 @@ export default function ImpactStoryteller({ repos }: ImpactStorytellerProps) {
                     </p>
                     <button
                       onClick={() => copyToClipboard(point, globalIdx)}
-                      className="absolute right-0 top-0 p-2 rounded-lg bg-white dark:bg-slate-900 border border-slate-100 dark:border-slate-800 opacity-0 group-hover/point:opacity-100 items-center justify-center transition-all hover:scale-105"
+                      className="absolute right-0 top-0 p-2 rounded-lg bg-white dark:bg-slate-900 border border-slate-100 dark:border-slate-800 opacity-0 group-hover/point:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 items-center justify-center transition-all hover:scale-105"
+                      aria-label={copiedIndex === globalIdx ? "Copied" : "Copy impact statement"}
+                      title={copiedIndex === globalIdx ? "Copied" : "Copy impact statement"}
                     >
                       {copiedIndex === globalIdx ? (
                         <Check size={14} className="text-emerald-500" />


### PR DESCRIPTION
💡 **What:** Added comprehensive accessibility features to the copy button within the `ImpactStoryteller` component. 
🎯 **Why:** The button was completely invisible and inaccessible to keyboard users because it only relied on `group-hover` opacity to appear. Now, it appears on focus, has visible focus rings, and correctly announces its action to screen readers. It also dynamically updates the tooltip and screen reader label to "Copied" upon successful copy.
♿ **Accessibility:**
- Added `focus-visible:opacity-100` so the button appears on tab focus.
- Added visible focus rings for keyboard navigation.
- Added dynamic `aria-label` and `title` for screen readers and tooltips.

---
*PR created automatically by Jules for task [7663423633026288492](https://jules.google.com/task/7663423633026288492) started by @SudoAnirudh*