### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and focus states to ImpactStoryteller copy button

### DIFF
--- a/frontend/components/github/ImpactStoryteller.tsx
+++ b/frontend/components/github/ImpactStoryteller.tsx
@@ -95,7 +95,9 @@ export default function ImpactStoryteller({ repos }: ImpactStorytellerProps) {
                     </p>
                     <button
                       onClick={() => copyToClipboard(point, globalIdx)}
-                      className="absolute right-0 top-0 p-2 rounded-lg bg-white dark:bg-slate-900 border border-slate-100 dark:border-slate-800 opacity-0 group-hover/point:opacity-100 items-center justify-center transition-all"
+                      aria-label="Copy to clipboard"
+                      title="Copy to clipboard"
+                      className="absolute right-0 top-0 p-2 rounded-lg bg-white dark:bg-slate-900 border border-slate-100 dark:border-slate-800 opacity-0 group-hover/point:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none items-center justify-center transition-all"
                     >
                       {copiedIndex === globalIdx ? (
                         <Check size={14} className="text-emerald-500" />


### PR DESCRIPTION
**What:** Added accessibility improvements to the copy button in ImpactStoryteller component. Added `aria-label`, `title`, and `focus-visible` classes. Added `.jules/palette.md` to document learning.

**Why:** Hover-revealed icon-only buttons often lack accessibility for keyboard users and screen readers. They require focus visibility and descriptive attributes so screen readers can interpret their actions and keyboard navigators can reach and identify them.

**Accessibility:** Added `aria-label` and `title` to the copy button, as well as `focus-visible:opacity-100`, `focus-visible:ring-2`, and `focus-visible:outline-none` classes to make it accessible to keyboard users and screen readers.

---
*PR created automatically by Jules for task [9284916955608093038](https://jules.google.com/task/9284916955608093038) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced keyboard navigation with improved visual focus indicators on interactive buttons.
  * Added accessibility attributes for better support of keyboard users and screen readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->