### PR TITLE
🎨 Palette: Improve keyboard accessibility on ResumeEditor toolbar

### DIFF
--- a/frontend/components/ResumeEditor.tsx
+++ b/frontend/components/ResumeEditor.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 
 const toolbarBtn =
-  "p-2 rounded-xl transition-all disabled:opacity-50 disabled:pointer-events-none #7C9ADD]/10 text-[#4A5568]";
+  "p-2 rounded-xl transition-all disabled:opacity-50 disabled:pointer-events-none hover:bg-[#7C9ADD]/10 hover:text-[#7C9ADD] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7C9ADD]/50 text-[#4A5568]";
 
 const MenuBar = ({
   editor,
@@ -51,7 +51,7 @@ const MenuBar = ({
   };
 
   const activeClass = "bg-[#7C9ADD]/10 text-[#7C9ADD] shadow-sm";
-  const idleClass = "text-[#718096] #7C9ADD]";
+  const idleClass = "text-[#718096] hover:text-[#7C9ADD]";
 
   return (
     <div className="flex flex-wrap items-center gap-1.5 p-3 sticky top-0 z-10 border-b border-white/60 bg-white/60 backdrop-blur-xl">
@@ -80,7 +80,7 @@ const MenuBar = ({
         <button
           onClick={() => editor.chain().focus().toggleBold().run()}
           disabled={!editor.can().chain().focus().toggleBold().run()}
-          className={`${toolbarBtn} ${editor.isActive("bold") ? "bg-[#7C9ADD]/10 text-[#7C9ADD] shadow-sm" : "text-[#718096] #7C9ADD]"}`}
+          className={`${toolbarBtn} ${editor.isActive("bold") ? "bg-[#7C9ADD]/10 text-[#7C9ADD] shadow-sm" : "text-[#718096] hover:text-[#7C9ADD]"}`}
           title="Bold"
           aria-label="Bold"
         >


### PR DESCRIPTION
💡 What: Added visible focus states and repaired broken hover states on icon-only buttons in the ResumeEditor toolbar.
🎯 Why: Keyboard users previously couldn't see which formatting button (bold, italic, etc.) was actively focused, making the editor difficult to navigate without a mouse.
📸 Before/After: Screenshots were taken in headless mode. 
♿ Accessibility: Ensures WCAG compliance for focus indicators and complete hover interactions.

---
*PR created automatically by Jules for task [10729342053324471891](https://jules.google.com/task/10729342053324471891) started by @SudoAnirudh*