### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix authorization bypass in RBAC dependencies

### DIFF
--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -124,10 +124,12 @@ async def get_current_user(
         # user_metadata lives in the JWT under the same key
         metadata = payload.get("user_metadata", {})
 
+        plan = metadata.get("plan", "free")
+
         return {
             "user_id": user_id,
             "email": email,
-            "plan": "pro"  # Hardcoded to 'pro' to bypass all feature gates
+            "plan": plan
         }
     except jwt.ExpiredSignatureError:
         raise HTTPException(
@@ -151,10 +153,11 @@ async def get_current_user(
             user = user_res.user
             metadata = getattr(user, "user_metadata", {}) or {}
             print("✅ Supabase network verification succeeded.")
+            plan = metadata.get("plan", "free")
             return {
                 "user_id": user.id,
                 "email": user.email,
-                "plan": "pro"  # Hardcoded to 'pro' to bypass all feature gates
+                "plan": plan
             }
         except Exception as net_e:
             print(f"❌ Supabase network verification failed: {net_e}")
@@ -169,7 +172,11 @@ def require_plan(*allowed_plans: str):
     """Factory that returns a dependency enforcing a minimum subscription plan."""
 
     async def _check_plan(user: dict = Depends(get_current_user)) -> dict:
-        # Plan enforcement disabled: everyone is 'pro'
+        if user.get("plan", "free") not in allowed_plans:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have access to this feature. Please upgrade your plan.",
+            )
         return user
 
     return _check_plan


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `backend/dependencies.py` module contained a hardcoded dictionary override forcing the authenticated user's `plan` to `"pro"`, bypassing all feature gates. Additionally, the `require_plan` dependency was completely disabled, returning the user object regardless of their plan.
🎯 Impact: Any authenticated user could access premium-only features (such as the GitHub deep analysis endpoint) without paying or having the required subscription tier, leading to resource abuse and broken access control.
🔧 Fix:
1. Updated `get_current_user` to correctly extract the `plan` from the `user_metadata` embedded in the JWT or the Supabase network response, safely defaulting to `"free"`.
2. Restored the logical check in `require_plan` to enforce the provided `allowed_plans` list, throwing a `403 Forbidden` `HTTPException` if unauthorized.
✅ Verification: Ran backend unittests successfully and performed a static security review. Code review passes.

---
*PR created automatically by Jules for task [15129424681955110432](https://jules.google.com/task/15129424681955110432) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plan-based access control to properly enforce feature restrictions based on user subscription tier.
  * Users are now correctly identified with their actual plan instead of receiving incorrect access levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->