### PR TITLE
🎨 Palette: Keyboard accessible resources tooltip in TechTree

### DIFF
--- a/frontend/components/dashboard/TechTreeNode.tsx
+++ b/frontend/components/dashboard/TechTreeNode.tsx
@@ -78,7 +78,7 @@ export default function TechTreeNode({
       <div className="flex items-center justify-between mt-4 gap-2">
         <button
           onClick={() => onToggle?.(skill.name)}
-          className={`flex-1 text-[10px] font-black uppercase tracking-widest py-2 rounded-xl transition-all ${
+          className={`flex-1 text-[10px] font-black uppercase tracking-widest py-2 rounded-xl transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50 ${
             isCompleted
               ? "bg-emerald-500 text-white shadow-lg shadow-emerald-500/20"
               : "bg-white/60 text-slate-600"
@@ -89,12 +89,15 @@ export default function TechTreeNode({
 
         {skill.resources && skill.resources.length > 0 && (
           <div className="group/res relative">
-            <div className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400">
+            <button
+              aria-label="View resources"
+              className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400"
+            >
               <ExternalLink size={14} />
-            </div>
+            </button>
 
             {/* Simple resources preview on hover */}
-            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible transition-all z-50 shadow-2xl">
+            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible group-focus-within/res:opacity-100 group-focus-within/res:visible transition-all z-50 shadow-2xl">
               <p className="font-black uppercase tracking-widest text-[#7C9ADD] mb-2">
                 Resources
               </p>


### PR DESCRIPTION
This PR introduces a micro-UX enhancement to the `TechTreeNode` component by making its resource tooltip fully accessible to keyboard users.

Before this change, the external link icon was a `div` element, meaning it could not receive keyboard focus, and the attached tooltip would only appear on mouse hover (`group-hover`). This completely blocked keyboard users and screen readers from accessing the attached resources list.

This update resolves the issue by:
1. Converting the icon container to a proper semantic `<button>`.
2. Adding an `aria-label="View resources"` for screen readers.
3. Applying `focus-visible:ring-2` styles to provide a clear visual indicator when the user tabs to the element.
4. Using Tailwind's `group-focus-within` on the tooltip container so that it becomes visible when the new button receives keyboard focus.

I also added similar `focus-visible` styles to the adjacent "Mark Done" button for consistency. Finally, I documented this critical accessibility learning in the `.jules/palette.md` journal.

---
*PR created automatically by Jules for task [4607438990303237549](https://jules.google.com/task/4607438990303237549) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced keyboard navigation with improved visual focus indicators for accessible browsing.
  * Resources panel now displays when keyboard-focused, expanding accessibility beyond mouse hover interactions.

* **Style**
  * Updated interactive element styling to include enhanced focus ring visibility and clearer keyboard navigation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->