### PR TITLE
🎨 Palette: Make TechTreeNode tooltip keyboard accessible

### DIFF
--- a/frontend/components/dashboard/TechTreeNode.tsx
+++ b/frontend/components/dashboard/TechTreeNode.tsx
@@ -89,12 +89,15 @@ export default function TechTreeNode({
 
         {skill.resources && skill.resources.length > 0 && (
           <div className="group/res relative">
-            <div className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400">
+            <button
+              aria-label={`View resources for ${skill.name}`}
+              className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            >
               <ExternalLink size={14} />
-            </div>
+            </button>
 
             {/* Simple resources preview on hover */}
-            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible transition-all z-50 shadow-2xl">
+            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible group-focus-within/res:opacity-100 group-focus-within/res:visible transition-all z-50 shadow-2xl">
               <p className="font-black uppercase tracking-widest text-[#7C9ADD] mb-2">
                 Resources
               </p>


### PR DESCRIPTION
💡 What: Replaced an unsemantic `<div>` trigger with an accessible `<button>` in `TechTreeNode.tsx`.
🎯 Why: The hover-revealed tooltip for resources was completely inaccessible to keyboard users and screen readers because the trigger could not receive focus.
♿ Accessibility: Added `aria-label`, explicit `focus-visible` styles, and `group-focus-within` to the tooltip container so keyboard navigation triggers it identically to mouse hover.

---
*PR created automatically by Jules for task [15528376774752073306](https://jules.google.com/task/15528376774752073306) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced keyboard navigation for the resources preview feature
  * Improved visual focus indicators for keyboard users
  * Better support for assistive technologies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->