### PR TITLE
🎨 Palette: Improve accessibility and focus rings in Resume Editor toolbar

### DIFF
--- a/frontend/components/ResumeEditor.tsx
+++ b/frontend/components/ResumeEditor.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 
 const toolbarBtn =
-  "p-2 rounded-xl transition-all disabled:opacity-50 disabled:pointer-events-none #7C9ADD]/10 text-[#4A5568]";
+  "p-2 rounded-xl transition-all disabled:opacity-50 disabled:pointer-events-none hover:bg-[#7C9ADD]/10 text-[#4A5568] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7C9ADD]/50";
 
 const MenuBar = ({
   editor,
@@ -51,7 +51,7 @@ const MenuBar = ({
   };
 
   const activeClass = "bg-[#7C9ADD]/10 text-[#7C9ADD] shadow-sm";
-  const idleClass = "text-[#718096] #7C9ADD]";
+  const idleClass = "text-[#718096] hover:text-[#7C9ADD]";
 
   return (
     <div className="flex flex-wrap items-center gap-1.5 p-3 sticky top-0 z-10 border-b border-white/60 bg-white/60 backdrop-blur-xl">
@@ -80,7 +80,7 @@ const MenuBar = ({
         <button
           onClick={() => editor.chain().focus().toggleBold().run()}
           disabled={!editor.can().chain().focus().toggleBold().run()}
-          className={`${toolbarBtn} ${editor.isActive("bold") ? "bg-[#7C9ADD]/10 text-[#7C9ADD] shadow-sm" : "text-[#718096] #7C9ADD]"}`}
+          className={`${toolbarBtn} ${editor.isActive("bold") ? activeClass : idleClass}`}
           title="Bold"
           aria-label="Bold"
         >


### PR DESCRIPTION
### 💡 What: 
Added `focus-visible` styles to the TipTap rich text editor toolbar buttons in `ResumeEditor.tsx` and restored broken `hover` states from an earlier regex replacement.

### 🎯 Why: 
Custom toolbar buttons without explicit focus rings make keyboard navigation essentially invisible to users tabbing through the interface. Restoring the malformed hover strings improves the mouse interaction feel.

### ♿ Accessibility:
Ensures keyboard accessibility for rich-text operations by adding `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7C9ADD]/50` to the shared `toolbarBtn` class.

---
*PR created automatically by Jules for task [1602960479234492596](https://jules.google.com/task/1602960479234492596) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed toolbar button styling in the resume editor to ensure consistent visual appearance and proper interaction states
- Corrected button hover and focus feedback states for clearer user interaction cues when formatting and editing documents
- Enhanced overall styling consistency across all toolbar controls to provide a more polished and professional editing experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->