### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information leakage in token error handling

### DIFF
--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -1,5 +1,6 @@
 import base64
 import time
+import logging
 from functools import lru_cache
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -7,6 +8,8 @@ import httpx
 import jwt
 from supabase import create_client, Client
 from config import settings
+
+logger = logging.getLogger("hirenix.dependencies")
 
 bearer_scheme = HTTPBearer(auto_error=False)
 SUPPORTED_ASYMMETRIC_ALGORITHMS = {"ES256", "RS256"}
@@ -138,9 +141,10 @@ async def get_current_user(
             headers={"WWW-Authenticate": "Bearer"},
         )
     except MalformedTokenError as exc:
+        logger.error(f"Malformed token error: {exc}")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=str(exc),
+            detail="Invalid authentication token.",
             headers={"WWW-Authenticate": "Bearer"},
         )
     except jwt.InvalidTokenError as exc:


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The application was exposing the raw exception string `str(exc)` directly in the FastAPI `HTTPException` detail when a `MalformedTokenError` occurred during JWT authentication in `backend/dependencies.py`.
🎯 **Impact:** Exposing raw internal exceptions to the client can inadvertently leak stack traces, architecture details, underlying library behaviors, or internal formatting expectations to an attacker.
🔧 **Fix:** Replaced the `detail=str(exc)` with a static, generic safe message (`detail="Invalid authentication token."`) and ensured the detailed exception is logged server-side using standard Python `logging`.
✅ **Verification:** Verified by running the backend linter (`ruff check`) and the test suite (`python3 -m unittest discover tests`) to confirm no regressions were introduced. Also recorded findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [4095022544682537831](https://jules.google.com/task/4095022544682537831) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error handling to provide consistent, secure error responses during token validation failures, enhancing the reliability of user authentication processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->