### PR TITLE
🎨 Palette: Make TechTreeNode resources tooltip keyboard accessible

### DIFF
--- a/frontend/components/dashboard/TechTreeNode.tsx
+++ b/frontend/components/dashboard/TechTreeNode.tsx
@@ -89,12 +89,20 @@ export default function TechTreeNode({
 
         {skill.resources && skill.resources.length > 0 && (
           <div className="group/res relative">
-            <div className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400">
+            <button
+              type="button"
+              aria-label="View resources"
+              aria-describedby={`resources-preview-${skill.name.replace(/\s+/g, '-').toLowerCase()}`}
+              className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            >
               <ExternalLink size={14} />
-            </div>
+            </button>
 
             {/* Simple resources preview on hover */}
-            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible transition-all z-50 shadow-2xl">
+            <div
+              id={`resources-preview-${skill.name.replace(/\s+/g, '-').toLowerCase()}`}
+              className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible group-focus-within/res:opacity-100 group-focus-within/res:visible transition-all z-50 shadow-2xl pointer-events-none"
+            >
               <p className="font-black uppercase tracking-widest text-[#7C9ADD] mb-2">
                 Resources
               </p>


### PR DESCRIPTION
💡 What: Converted the non-interactive div trigger for the resources preview into a semantic button with an `aria-label`, focus styles, and programmatic linkage (`aria-describedby`) to the tooltip content. Added `group-focus-within/res` to the tooltip to reveal it on focus.
🎯 Why: Sighted keyboard users could not access or reveal the resources tooltip, and screen readers lacked semantic context for what the trigger did.
📸 Before/After: Visuals remain unchanged on hover, but a focus ring now appears when navigating via keyboard, and the tooltip displays.
♿ Accessibility: Improved keyboard navigability by using a `<button>`, ensuring it receives focus, adding `focus-visible` styles, and using `aria-describedby` to announce the tooltip contents to screen readers.

---
*PR created automatically by Jules for task [16421717964268041951](https://jules.google.com/task/16421717964268041951) started by @SudoAnirudh*