### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file upload

### DIFF
--- a/backend/utils/file_handler.py
+++ b/backend/utils/file_handler.py
@@ -3,9 +3,13 @@ import os
 from fastapi import UploadFile
 
 
+import uuid
+
 async def save_upload_temp(file: UploadFile) -> str:
     """Save an uploaded file to /tmp and return the temp path."""
-    tmp_path = f"/tmp/{file.filename}"
+    safe_filename = os.path.basename(file.filename)
+    unique_filename = f"{uuid.uuid4()}_{safe_filename}"
+    tmp_path = f"/tmp/{unique_filename}"
     content = await file.read()
     async with aiofiles.open(tmp_path, "wb") as f:
         await f.write(content)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `save_upload_temp` function in `backend/utils/file_handler.py` constructs a temporary file path by directly concatenating the user-provided `file.filename` (e.g., `/tmp/{file.filename}`). This created a path traversal vulnerability and allowed file clobbering.
🎯 **Impact:** An attacker could craft a malicious filename (e.g., `../../../etc/passwd`) to write files outside of `/tmp/`, potentially overwriting arbitrary files on the server or escaping the intended directory. Additionally, simultaneous uploads with the same filename could cause race conditions.
🔧 **Fix:** Sanitized the filename using `os.path.basename()` to strip any directory paths, and prepended a unique UUID (`uuid.uuid4()`) to ensure absolute uniqueness and constraint to the target `/tmp` directory.
✅ **Verification:** Ran `cd backend && PYTHONPATH=. python3 -m unittest discover tests` successfully and checked `cd backend && ruff check .`. No new errors related to the file handler were introduced. Evaluated correctness via code review. Evaluated memory format via `cat .jules/sentinel.md`.

---
*PR created automatically by Jules for task [8351902808689761092](https://jules.google.com/task/8351902808689761092) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary file handling for concurrent uploads to prevent file collisions and ensure reliable file storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->