### PR TITLE
⚡ Bolt: Parallelize database queries in cover letter export

### DIFF
--- a/backend/routers/cover_letter.py
+++ b/backend/routers/cover_letter.py
@@ -1,5 +1,6 @@
 import uuid
 import datetime
+import asyncio
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from dependencies import get_current_user, get_supabase_admin
@@ -93,25 +94,18 @@ async def export_cover_letter(
     db=Depends(get_supabase_admin),
 ):
     """Exports a cover letter as PDF or Docx."""
-    r = (
-        db.table("cover_letters")
-        .select("*")
-        .eq("id", letter_id)
-        .eq("user_id", user["user_id"])
-        .single()
-        .execute()
-    )
+    # ⚡ Bolt: Parallelize independent database queries
+    # What: Uses asyncio.gather with asyncio.to_thread to run 2 Supabase queries concurrently.
+    # Why: The Supabase python client is synchronous; calling .execute() in series blocks the async event loop and increases latency.
+    # Impact: Reduces query time from ~2N to ~1N, significantly speeding up the cover letter export.
+
+    cover_letter_task = asyncio.to_thread(lambda: db.table("cover_letters").select("*").eq("id", letter_id).eq("user_id", user["user_id"]).single().execute())
+    profile_task = asyncio.to_thread(lambda: db.table("profiles").select("full_name").eq("id", user["user_id"]).single().execute())
+
+    r, p = await asyncio.gather(cover_letter_task, profile_task)
+
     if not r.data:
         raise HTTPException(status_code=404, detail="Cover letter not found.")
-
-    # Fetch user profile for headers
-    p = (
-        db.table("profiles")
-        .select("full_name")
-        .eq("id", user["user_id"])
-        .single()
-        .execute()
-    )
     
     header_info = {
         "name": p.data.get("full_name", "Valued User"),


### PR DESCRIPTION
💡 What: Refactored the `export_cover_letter` endpoint in `backend/routers/cover_letter.py` to use `asyncio.gather` with `asyncio.to_thread` for fetching the cover letter and user profile from Supabase.
🎯 Why: The Supabase python client (v2.4.3) is synchronous. Executing `.execute()` directly within the `async def` route blocks the FastAPI asyncio event loop, causing requests to be processed sequentially and degrading overall application concurrency.
📊 Impact: Reduces database query time from ~2N to ~1N for the export operation, speeding up the PDF/Docx generation request significantly. Frees up the main event loop from waiting on network I/O.
🔬 Measurement: Verified functionality by running backend test suites. Linter checks passing cleanly. The new logic was added ensuring the `HTTPException` fires exactly when `r.data` is not present, replicating existing application behavior but with concurrent DB retrieval.

---
*PR created automatically by Jules for task [12686792690698629372](https://jules.google.com/task/12686792690698629372) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved efficiency of cover letter export operations through parallel data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->