### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS risk in file uploads by enforcing size limits

### DIFF
--- a/backend/routers/job_match.py
+++ b/backend/routers/job_match.py
@@ -97,10 +97,14 @@ async def match_job_upload(
 ):
     """Compare an uploaded resume (PDF) against job description (text or file) and return match results."""
     # 1. Parse Resume
-    resume_content = await resume_file.read()
     if not resume_file.filename.lower().endswith(".pdf"):
         raise HTTPException(status_code=400, detail="Resume must be a PDF.")
     
+    if resume_file.size and resume_file.size > 10 * 1024 * 1024:
+        raise HTTPException(status_code=413, detail="Resume file too large. Max size is 10MB.")
+
+    resume_content = await resume_file.read()
+
     _, resume_text = parse_resume(resume_content)
     if not resume_text.strip():
         raise HTTPException(status_code=400, detail="Could not extract text from resume.")
@@ -108,6 +112,8 @@ async def match_job_upload(
     # 2. Extract JD Text
     final_jd_text = jd_text or ""
     if jd_file:
+         if jd_file.size and jd_file.size > 10 * 1024 * 1024:
+             raise HTTPException(status_code=413, detail="JD file too large. Max size is 10MB.")
          jd_content = await jd_file.read()
          if jd_file.filename.lower().endswith(".pdf"):
              final_jd_text = extract_pdf_text(jd_content)

--- a/backend/routers/linkedin.py
+++ b/backend/routers/linkedin.py
@@ -19,6 +19,9 @@ async def analyze_linkedin(
     if file.content_type != "application/pdf":
         raise HTTPException(status_code=400, detail="Only PDF files are supported.")
 
+    if file.size and file.size > 5 * 1024 * 1024:
+        raise HTTPException(status_code=413, detail="File too large. Max size is 5MB.")
+
     try:
         content = await file.read()
         analysis = await analyze_linkedin_profile(content)

--- a/backend/routers/resume.py
+++ b/backend/routers/resume.py
@@ -20,6 +20,9 @@ async def upload_resume(
     if not file.filename or not file.filename.lower().endswith(".pdf"):
         raise HTTPException(status_code=400, detail="Only PDF files are supported.")
 
+    if file.size and file.size > MAX_RESUME_SIZE_BYTES:
+        raise HTTPException(status_code=413, detail="File too large. Max size is 10MB.")
+
     content = await file.read()
     if not content:
         raise HTTPException(status_code=400, detail="Uploaded file is empty.")

--- a/backend/scripts/roadmap_scraper.py
+++ b/backend/scripts/roadmap_scraper.py
@@ -1,7 +1,7 @@
 import os
 import json
 import requests
-from typing import List, Dict, Any, Optional
+from typing import Any, Optional
 from concurrent.futures import ThreadPoolExecutor
 
 # Configuration

--- a/backend/services/roadmap_engine.py
+++ b/backend/services/roadmap_engine.py
@@ -1,12 +1,11 @@
 import os
 import logging
 import json
-from typing import Optional, Dict, List
-from models.roadmap import CareerRoadmap, RoadmapSkill
+from typing import Optional
+from models.roadmap import CareerRoadmap
 from services.skill_gap import detect_skill_gap
 from services.nvidia_client import invoke_nvidia_llm
 from services.groq_client import invoke_groq_llm
-from services.cache_manager import cache_manager
 from utils.link_validator import validate_links, get_fallback_url
 from config import settings
 


### PR DESCRIPTION
This PR adds an explicit size constraint check for file upload endpoints. Previously, files were read entirely into memory (`await file.read()`) before size constraints like `len(content)` were evaluated. This creates a Denial of Service vector where a malicious actor could upload gigabytes of data to exhaust server memory.

Now, we check the `file.size` attribute provided by FastAPI (which uses `Content-Length` headers or temp file size) to immediately reject files over the allowed limit (5MB for LinkedIn profile PDF, 10MB for resumes/JDs) before reading.

---
*PR created automatically by Jules for task [7023581355539964341](https://jules.google.com/task/7023581355539964341) started by @SudoAnirudh*