### PR TITLE
🎨 Palette: Make TechTreeNode resources tooltip keyboard accessible

### DIFF
--- a/frontend/components/dashboard/TechTreeNode.tsx
+++ b/frontend/components/dashboard/TechTreeNode.tsx
@@ -89,12 +89,16 @@ export default function TechTreeNode({
 
         {skill.resources && skill.resources.length > 0 && (
           <div className="group/res relative">
-            <div className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400">
+            <button
+              type="button"
+              aria-label="View resources"
+              className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/50 block"
+            >
               <ExternalLink size={14} />
-            </div>
+            </button>
 
             {/* Simple resources preview on hover */}
-            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible transition-all z-50 shadow-2xl">
+            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible group-focus-within/res:opacity-100 group-focus-within/res:visible transition-all z-50 shadow-2xl">
               <p className="font-black uppercase tracking-widest text-[#7C9ADD] mb-2">
                 Resources
               </p>


### PR DESCRIPTION
💡 **What**:
The resources tooltip in the `TechTreeNode` component was previously triggered only by hovering over a non-interactive `div`. This PR replaces the `div` with a semantic `<button type="button">`, adds `group-focus-within` to the tooltip container, and applies explicit `focus-visible` styles to the trigger.

🎯 **Why**:
Users navigating via keyboard (such as those using screen readers or traversing the page with the Tab key) could not access or reveal the resources tooltip, as hover styles (`group-hover`) only apply to mouse interactions.

♿ **Accessibility**:
- Wrapped the trigger icon in a proper `<button type="button">` element, allowing it to receive keyboard focus.
- Added `aria-label="View resources"` so screen readers can interpret the button's purpose.
- Implemented `group-focus-within/res:opacity-100 group-focus-within/res:visible` on the tooltip container so it becomes visible when the trigger receives keyboard focus.
- Added `focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-indigo-500/50` to the trigger for clear visual feedback for keyboard users.

---
*PR created automatically by Jules for task [13287980151076837884](https://jules.google.com/task/13287980151076837884) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced the resources trigger with improved keyboard accessibility and clearer visual focus indicators for better interactive usability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SudoAnirudh/Hirenix/pull/115)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->