### PR TITLE
🎨 Palette: Accessible Status Toggle in Vertical Roadmap

### DIFF
--- a/frontend/app/dashboard/account/page.tsx
+++ b/frontend/app/dashboard/account/page.tsx
@@ -23,7 +23,7 @@ import { getSession, signOut } from "@/lib/auth";
 import { getProgress } from "@/lib/api";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { LoadingScreen } from "@/components/ui/LoadingScreen";
+import LoadingScreen from "@/components/ui/LoadingScreen";
 import { useRouter } from "next/navigation";
 
 interface UserSession {

--- a/frontend/app/dashboard/progress-tracker/page.tsx
+++ b/frontend/app/dashboard/progress-tracker/page.tsx
@@ -18,6 +18,7 @@ import {
 import ReactMarkdown from "react-markdown";
 import { Sparkles, Loader2, Copy, FileText, Check, Rocket } from "lucide-react";
 import { toast } from "sonner";
+import LoadingScreen from "@/components/ui/LoadingScreen";
 import { useReactToPrint } from "react-to-print";
 
 interface TrendPoint {

--- a/frontend/components/dashboard/VerticalRoadmap.tsx
+++ b/frontend/components/dashboard/VerticalRoadmap.tsx
@@ -114,11 +114,12 @@ function RoadmapNode({
         {/* Status Indicator (Vibrant Circle) */}
         <div className="relative flex-shrink-0">
           <button
+            aria-label={skill.status === "completed" ? "Mark as incomplete" : "Mark as completed"}
             onClick={(e) => {
               e.stopPropagation();
               onToggleStatus(skill.name);
             }}
-            className={`z-10 relative flex items-center justify-center w-10 h-10 rounded-full transition-all active:scale-90 ${
+            className={`z-10 relative flex items-center justify-center w-10 h-10 rounded-full transition-all active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 ${
               skill.status === "completed"
                 ? "bg-gradient-to-br from-emerald-400 to-teal-500 text-white shadow-lg shadow-emerald-500/30"
                 : "bg-slate-100 dark:bg-slate-800 text-slate-400 hover:text-indigo-500 hover:bg-indigo-50 dark:hover:bg-indigo-900/30"


### PR DESCRIPTION
### 💡 What:
- Added dynamic `aria-label` to the status toggle button in `VerticalRoadmap.tsx`.
- Added `focus-visible:ring-2`, `focus-visible:ring-indigo-500`, and `focus-visible:outline-none` styles to the same button.
- Fixed an invalid named import for the `LoadingScreen` component in `account/page.tsx` and `progress-tracker/page.tsx` which was causing `pnpm build` and `pnpm lint` errors.

### 🎯 Why:
The status toggle button in the vertical roadmap is an icon-only button without any text context, making it inaccessible to screen readers. It also lacked a distinct focus state, making keyboard navigation difficult.

### ♿ Accessibility:
- **Screen Readers:** Screen readers can now correctly announce the action (e.g., "Mark as completed" or "Mark as incomplete") when focusing on the skill node status toggle.
- **Keyboard Navigation:** Users relying on keyboard navigation can clearly see which interactive element currently has focus thanks to the explicit focus ring styling.

---
*PR created automatically by Jules for task [4682782193541469918](https://jules.google.com/task/4682782193541469918) started by @SudoAnirudh*