### PR TITLE
🎨 Palette: TechTreeNode accessibility improvement

### DIFF
--- a/frontend/app/dashboard/account/page.tsx
+++ b/frontend/app/dashboard/account/page.tsx
@@ -23,7 +23,7 @@ import { getSession, signOut } from "@/lib/auth";
 import { getProgress } from "@/lib/api";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { LoadingScreen } from "@/components/ui/LoadingScreen";
+import LoadingScreen from "@/components/ui/LoadingScreen";
 import { useRouter } from "next/navigation";
 
 interface UserSession {

--- a/frontend/app/dashboard/progress-tracker/page.tsx
+++ b/frontend/app/dashboard/progress-tracker/page.tsx
@@ -19,6 +19,7 @@ import ReactMarkdown from "react-markdown";
 import { Sparkles, Loader2, Copy, FileText, Check, Rocket } from "lucide-react";
 import { toast } from "sonner";
 import { useReactToPrint } from "react-to-print";
+import LoadingScreen from "@/components/ui/LoadingScreen";
 
 interface TrendPoint {
   score: number;

--- a/frontend/app/dashboard/roadmap/page.tsx
+++ b/frontend/app/dashboard/roadmap/page.tsx
@@ -130,7 +130,7 @@ export default function RoadmapPage() {
 
     // Flatten all completed skills for the backend
     const getCompletedNames = (skills: RoadmapSkill[]): string[] => {
-      let names: string[] = [];
+      const names: string[] = [];
       skills.forEach((s) => {
         if (s.status === "completed") names.push(s.name);
         if (s.children) names.push(...getCompletedNames(s.children));

--- a/frontend/components/dashboard/TechTreeNode.tsx
+++ b/frontend/components/dashboard/TechTreeNode.tsx
@@ -78,7 +78,8 @@ export default function TechTreeNode({
       <div className="flex items-center justify-between mt-4 gap-2">
         <button
           onClick={() => onToggle?.(skill.name)}
-          className={`flex-1 text-[10px] font-black uppercase tracking-widest py-2 rounded-xl transition-all ${
+          aria-label={`Toggle completion status for ${skill.name}`}
+          className={`flex-1 text-[10px] font-black uppercase tracking-widest py-2 rounded-xl transition-all focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${
             isCompleted
               ? "bg-emerald-500 text-white shadow-lg shadow-emerald-500/20"
               : "bg-white/60 text-slate-600"
@@ -89,12 +90,16 @@ export default function TechTreeNode({
 
         {skill.resources && skill.resources.length > 0 && (
           <div className="group/res relative">
-            <div className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400">
+            <button
+              type="button"
+              aria-label={`View resources for ${skill.name}`}
+              className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none focus-visible:opacity-100"
+            >
               <ExternalLink size={14} />
-            </div>
+            </button>
 
             {/* Simple resources preview on hover */}
-            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible transition-all z-50 shadow-2xl">
+            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible group-focus-within:opacity-100 group-focus-within:visible transition-all z-50 shadow-2xl">
               <p className="font-black uppercase tracking-widest text-[#7C9ADD] mb-2">
                 Resources
               </p>


### PR DESCRIPTION
🎨 Palette: [TechTreeNode accessibility]

💡 What: Converted the `ExternalLink` icon's `div` wrapper to a semantic `<button>` with an `aria-label` and `focus-visible` styles, and applied `group-focus-within` styling to its associated tooltip. Added `aria-label` and focus styling to the "Mark Done" button.
🎯 Why: Tooltips revealed via `group-hover:opacity-100` are entirely inaccessible to keyboard users unless explicitly given a focus state. Converting the wrapper to a semantic button allows tab targeting, and the `group-focus-within` on the tooltip allows keyboard users to reveal it organically.
📸 Before/After: Visuals remain unchanged for mouse users, but keyboard users can now tab to the "Mark Done" and "Resources" buttons with clear focus rings, and view the tooltip.
♿ Accessibility: Increased accessibility of interactive UI elements by guaranteeing proper focus targeting and semantics.

---
*PR created automatically by Jules for task [3190766088856365505](https://jules.google.com/task/3190766088856365505) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility & Keyboard Navigation**
  * Enhanced keyboard navigation with improved focus indicators for dashboard interactive elements.
  * Better semantic markup and labels for improved screen reader support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SudoAnirudh/Hirenix/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->