### PR TITLE
🎨 Palette: Tooltip keyboard accessibility for resources

### DIFF
--- a/frontend/components/dashboard/TechTreeNode.tsx
+++ b/frontend/components/dashboard/TechTreeNode.tsx
@@ -78,7 +78,7 @@ export default function TechTreeNode({
       <div className="flex items-center justify-between mt-4 gap-2">
         <button
           onClick={() => onToggle?.(skill.name)}
-          className={`flex-1 text-[10px] font-black uppercase tracking-widest py-2 rounded-xl transition-all ${
+          className={`flex-1 text-[10px] font-black uppercase tracking-widest py-2 rounded-xl transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
             isCompleted
               ? "bg-emerald-500 text-white shadow-lg shadow-emerald-500/20"
               : "bg-white/60 text-slate-600"
@@ -89,12 +89,15 @@ export default function TechTreeNode({
 
         {skill.resources && skill.resources.length > 0 && (
           <div className="group/res relative">
-            <div className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400">
+            <button
+              aria-label={`View resources for ${skill.name}`}
+              className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 block"
+            >
               <ExternalLink size={14} />
-            </div>
+            </button>
 
             {/* Simple resources preview on hover */}
-            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible transition-all z-50 shadow-2xl">
+            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible group-focus-within/res:opacity-100 group-focus-within/res:visible transition-all z-50 shadow-2xl">
               <p className="font-black uppercase tracking-widest text-[#7C9ADD] mb-2">
                 Resources
               </p>


### PR DESCRIPTION
💡 **What:** Replaced the non-interactive `div` wrapping the `ExternalLink` icon in `TechTreeNode.tsx` with a semantic `<button>` containing an `aria-label`. Additionally, added `group-focus-within` styling to the tooltip container and `focus-visible` ring styling to the buttons.
🎯 **Why:** To ensure the hover-revealed resources menu is fully accessible via keyboard navigation. Previously, keyboard users could not reveal or read the resources list.
♿ **Accessibility:**
- Added `aria-label="View resources for [Skill Name]"` to the trigger button for screen readers.
- Added `focus-visible:ring-2 focus-visible:ring-indigo-500` to interactable elements to show visible focus indicators.
- Ensured the tooltip stays open using `group-focus-within/res:visible` when its internal structure (or the trigger) is focused.

---
*PR created automatically by Jules for task [14457897235309986842](https://jules.google.com/task/14457897235309986842) started by @SudoAnirudh*