### PR TITLE
⚡ Bolt: Prevent event loop blocking and reduce latency in job suggester via asyncio.gather

### DIFF
--- a/backend/services/job_suggester.py
+++ b/backend/services/job_suggester.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import uuid
+import asyncio
 from typing import Dict, Any
 
 from services.job_scraper import scrape_jobs
@@ -15,20 +16,20 @@ async def get_user_readiness_context(user_id: str, db) -> Dict[str, Any]:
     Synthesizes user profile, resume, interview, and GitHub data for suggestion context.
     """
     try:
-        # 1. Latest Resume
-        resume_r = db.table("resumes").select("raw_text, ats_score").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+        # Execute independent queries concurrently to prevent event loop blocking
+        resume_task = asyncio.to_thread(lambda: db.table("resumes").select("raw_text, ats_score").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
+        interviews_task = asyncio.to_thread(lambda: db.table("interview_sessions").select("id, overall_score, target_role").eq("user_id", user_id).order("created_at", desc=True).limit(3).execute())
+        github_task = asyncio.to_thread(lambda: db.table("github_analyses").select("gpi_score, strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
         
-        # 2. Latest Interview Sessions
-        interviews_r = db.table("interview_sessions").select("id, overall_score, target_role").eq("user_id", user_id).order("created_at", desc=True).limit(3).execute()
-        
-        # 3. GitHub Stats
-        github_r = db.table("github_analyses").select("gpi_score, strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+        resume_r, interviews_r, github_r = await asyncio.gather(
+            resume_task, interviews_task, github_task
+        )
         
         # 4. Ready Skills from Interviews (score >= 7.0)
         ready_skills = []
         if interviews_r.data:
             session_ids = [i["id"] for i in interviews_r.data]
-            answers_r = db.table("interview_answers").select("category, score").in_("session_id", session_ids).execute()
+            answers_r = await asyncio.to_thread(lambda: db.table("interview_answers").select("category, score").in_("session_id", session_ids).execute())
             if answers_r.data:
                 ready_skills = list(set([a["category"] for a in answers_r.data if a["score"] and a["score"] >= 7.0 and a["category"]]))
 


### PR DESCRIPTION
💡 What: 
Refactored `get_user_readiness_context` in `backend/services/job_suggester.py` to use `asyncio.gather` on sequential, synchronous Supabase queries wrapped in `asyncio.to_thread`.
🎯 Why: 
The Supabase Python client's `.execute()` method is blocking and sequential. Calling it inside an `async def` function blocked the event loop causing N+1 latency bottlenecks and decreased throughput.
📊 Impact: 
Significantly reduces endpoint latency by fetching `resume`, `interviews`, and `github` data concurrently, unblocking the event loop.
🔬 Measurement:
Run backend unit tests and endpoints that rely on `job_suggester`. Latency benchmarks for `/api/jobs/suggest` will reflect improved times.

---
*PR created automatically by Jules for task [12993061182411813538](https://jules.google.com/task/12993061182411813538) started by @SudoAnirudh*