### PR TITLE
⚡ Bolt: Prevent synchronous Supabase database calls from blocking the async event loop

### DIFF
--- a/backend/scripts/roadmap_scraper.py
+++ b/backend/scripts/roadmap_scraper.py
@@ -1,7 +1,7 @@
 import os
 import json
 import requests
-from typing import List, Dict, Any, Optional
+from typing import Any, Optional
 from concurrent.futures import ThreadPoolExecutor
 
 # Configuration

--- a/backend/services/job_suggester.py
+++ b/backend/services/job_suggester.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import uuid
@@ -15,20 +16,30 @@ async def get_user_readiness_context(user_id: str, db) -> Dict[str, Any]:
     Synthesizes user profile, resume, interview, and GitHub data for suggestion context.
     """
     try:
-        # 1. Latest Resume
-        resume_r = db.table("resumes").select("raw_text, ats_score").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+        # 1-3. Fetch Resume, Interview Sessions, and GitHub Stats concurrently without blocking the event loop
         
-        # 2. Latest Interview Sessions
-        interviews_r = db.table("interview_sessions").select("id, overall_score, target_role").eq("user_id", user_id).order("created_at", desc=True).limit(3).execute()
-        
-        # 3. GitHub Stats
-        github_r = db.table("github_analyses").select("gpi_score, strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+        def fetch_resume():
+            return db.table("resumes").select("raw_text, ats_score").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+
+        def fetch_interviews():
+            return db.table("interview_sessions").select("id, overall_score, target_role").eq("user_id", user_id).order("created_at", desc=True).limit(3).execute()
+
+        def fetch_github():
+            return db.table("github_analyses").select("gpi_score, strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+
+        resume_r, interviews_r, github_r = await asyncio.gather(
+            asyncio.to_thread(fetch_resume),
+            asyncio.to_thread(fetch_interviews),
+            asyncio.to_thread(fetch_github)
+        )
         
         # 4. Ready Skills from Interviews (score >= 7.0)
         ready_skills = []
         if interviews_r.data:
             session_ids = [i["id"] for i in interviews_r.data]
-            answers_r = db.table("interview_answers").select("category, score").in_("session_id", session_ids).execute()
+            def fetch_answers():
+                return db.table("interview_answers").select("category, score").in_("session_id", session_ids).execute()
+            answers_r = await asyncio.to_thread(fetch_answers)
             if answers_r.data:
                 ready_skills = list(set([a["category"] for a in answers_r.data if a["score"] and a["score"] >= 7.0 and a["category"]]))
 

--- a/backend/services/outreach_service.py
+++ b/backend/services/outreach_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from typing import Optional, Any
@@ -16,8 +17,11 @@ async def generate_outreach_drafts(
     Generates personalized LinkedIn and Email outreach drafts using Hirenix AI.
     """
     try:
+
         # 1. Fetch Job Match Data
-        match_query = db.table("job_matches").select("*").eq("id", match_id).eq("user_id", user_id).single().execute()
+        def fetch_match():
+            return db.table("job_matches").select("*").eq("id", match_id).eq("user_id", user_id).single().execute()
+        match_query = await asyncio.to_thread(fetch_match)
         if not match_query.data:
             logger.error(f"Job match {match_id} not found for user {user_id}")
             return None
@@ -30,7 +34,9 @@ async def generate_outreach_drafts(
         bridge_advice = match_data.get("metadata", {}).get("bridge_advice", [])
 
         # 2. Fetch LinkedIn Profile Summary (for personalization)
-        li_query = db.table("linkedin_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+        def fetch_linkedin():
+            return db.table("linkedin_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+        li_query = await asyncio.to_thread(fetch_linkedin)
         
         profile_context = ""
         if li_query.data:
@@ -43,7 +49,9 @@ async def generate_outreach_drafts(
             profile_context = f"User Profile Summary: {profile_summary}\nKey Strengths: {', '.join(strengths)}"
         else:
             # Fallback to resume if LinkedIn not available
-            resume_query = db.table("resumes").select("raw_text").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+            def fetch_resume():
+                return db.table("resumes").select("raw_text").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+            resume_query = await asyncio.to_thread(fetch_resume)
             if resume_query.data:
                 profile_context = f"Candidate Background: {resume_query.data[0].get('raw_text', '')[:1000]}"
 

--- a/backend/services/roadmap_engine.py
+++ b/backend/services/roadmap_engine.py
@@ -1,12 +1,11 @@
 import os
 import logging
 import json
-from typing import Optional, Dict, List
-from models.roadmap import CareerRoadmap, RoadmapSkill
+from typing import Optional
+from models.roadmap import CareerRoadmap
 from services.skill_gap import detect_skill_gap
 from services.nvidia_client import invoke_nvidia_llm
 from services.groq_client import invoke_groq_llm
-from services.cache_manager import cache_manager
 from utils.link_validator import validate_links, get_fallback_url
 from config import settings
 

--- a/backend/services/semantic_cache.py
+++ b/backend/services/semantic_cache.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Optional, Dict, Any
 from dependencies import get_supabase_admin
@@ -20,15 +21,17 @@ async def check_semantic_cache(document_type: str, text: str) -> Optional[Dict[s
     try:
         supabase = get_supabase_admin()
         
-        response = supabase.rpc(
-            "match_semantic_cache",
-            {
-                "query_embedding": embedding,
-                "match_threshold": SIMILARITY_THRESHOLD,
-                "match_count": 1,
-                "doc_type": document_type
-            }
-        ).execute()
+        def run_rpc():
+            return supabase.rpc(
+                "match_semantic_cache",
+                {
+                    "query_embedding": embedding,
+                    "match_threshold": SIMILARITY_THRESHOLD,
+                    "match_count": 1,
+                    "doc_type": document_type
+                }
+            ).execute()
+        response = await asyncio.to_thread(run_rpc)
         
         data = response.data
         if data and len(data) > 0:
@@ -52,12 +55,14 @@ async def set_semantic_cache(document_type: str, text: str, llm_response: Dict[s
     try:
         supabase = get_supabase_admin()
         
-        supabase.table("llm_semantic_cache").insert({
-            "document_type": document_type,
-            "content_text": text,
-            "embedding": embedding,
-            "llm_response": llm_response
-        }).execute()
+        def run_insert():
+            return supabase.table("llm_semantic_cache").insert({
+                "document_type": document_type,
+                "content_text": text,
+                "embedding": embedding,
+                "llm_response": llm_response
+            }).execute()
+        await asyncio.to_thread(run_insert)
         
         logger.info(f"💾 Semantic Cache Set for {document_type}")
     except Exception as e:


### PR DESCRIPTION
💡 **What:** Refactored synchronous, blocking Supabase database queries (`.execute()`) inside FastAPI asynchronous endpoints to run in background threads using `asyncio.to_thread()`, and utilized `asyncio.gather()` to run independent queries concurrently.

🎯 **Why:** The Supabase Python client (`supabase-py` v2.4.3) used in this repository relies on synchronous `httpx` and `postgrest` calls under the hood. When `db.table(...).execute()` is invoked directly inside an `async def` function, it completely blocks the single threaded `asyncio` event loop. Under concurrent load, this causes a severe "N+1" style latency bottleneck for all endpoints.

📊 **Impact:** Expected to dramatically improve backend endpoint throughput and reduce latency under load by freeing up the event loop to handle concurrent web requests while waiting on database I/O. For endpoints fetching multiple sequential records (like `get_user_readiness_context`), executing queries concurrently via `gather` will roughly reduce database fetch time by ~50-60%.

🔬 **Measurement:** Can be verified by running load testing tools (like `locust` or `wrk`) against endpoints depending on `job_suggester` or `outreach_service`, and observing a decrease in p95 latency and an increase in Requests Per Second (RPS) compared to the unoptimized baseline.

---
*PR created automatically by Jules for task [15166661527549198924](https://jules.google.com/task/15166661527549198924) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized backend data fetching operations through concurrent execution, improving overall system performance and responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SudoAnirudh/Hirenix/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->