### PR TITLE
🎨 Palette: TechTreeNode Tooltip Accessibility

### DIFF
--- a/frontend/app/dashboard/account/page.tsx
+++ b/frontend/app/dashboard/account/page.tsx
@@ -23,7 +23,7 @@ import { getSession, signOut } from "@/lib/auth";
 import { getProgress } from "@/lib/api";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { LoadingScreen } from "@/components/ui/LoadingScreen";
+import LoadingScreen from "@/components/ui/LoadingScreen";
 import { useRouter } from "next/navigation";
 
 interface UserSession {

--- a/frontend/app/dashboard/progress-tracker/page.tsx
+++ b/frontend/app/dashboard/progress-tracker/page.tsx
@@ -19,6 +19,7 @@ import ReactMarkdown from "react-markdown";
 import { Sparkles, Loader2, Copy, FileText, Check, Rocket } from "lucide-react";
 import { toast } from "sonner";
 import { useReactToPrint } from "react-to-print";
+import LoadingScreen from "@/components/ui/LoadingScreen";
 
 interface TrendPoint {
   score: number;

--- a/frontend/components/dashboard/TechTreeNode.tsx
+++ b/frontend/components/dashboard/TechTreeNode.tsx
@@ -89,12 +89,17 @@ export default function TechTreeNode({
 
         {skill.resources && skill.resources.length > 0 && (
           <div className="group/res relative">
-            <div className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400">
+            <button
+              type="button"
+              aria-label="View resources"
+              title="View resources"
+              className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            >
               <ExternalLink size={14} />
-            </div>
+            </button>
 
             {/* Simple resources preview on hover */}
-            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible transition-all z-50 shadow-2xl">
+            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible group-focus-within/res:opacity-100 group-focus-within/res:visible transition-all z-50 shadow-2xl">
               <p className="font-black uppercase tracking-widest text-[#7C9ADD] mb-2">
                 Resources
               </p>


### PR DESCRIPTION
## 🎨 Palette: TechTreeNode Tooltip Accessibility

**💡 What:** 
Improved the keyboard accessibility of the "Resources" hover-revealed tooltip on the `TechTreeNode` component. The non-semantic `div` trigger was converted to a `<button>` with explicit ARIA labels and focus rings, and the tooltip container was updated to reveal itself on `group-focus-within`. Additionally, fixed a minor build issue related to `LoadingScreen` imports in the dashboard.

**🎯 Why:** 
Hover-revealed tooltips attached to non-semantic elements are entirely inaccessible to keyboard and screen reader users. By making the trigger a semantic button and linking the tooltip's visibility to focus within the group, all users can discover and interact with the resources linked to a skill node.

**♿ Accessibility:**
- Converted `div` to `button` for inherent focusability.
- Added `aria-label="View resources"`.
- Added visible focus ring (`focus-visible:ring-2`).
- Linked tooltip visibility to keyboard focus via `group-focus-within`.

---
*PR created automatically by Jules for task [3752610271931565726](https://jules.google.com/task/3752610271931565726) started by @SudoAnirudh*