### PR TITLE
🎨 Palette: Improve keyboard accessibility in dashboard components

### DIFF
--- a/frontend/components/dashboard/SkillDrawer.tsx
+++ b/frontend/components/dashboard/SkillDrawer.tsx
@@ -51,7 +51,8 @@ export default function SkillDrawer({
             </h2>
             <button
               onClick={onClose}
-              className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 transition-colors"
+              aria-label="Close skill details"
+              className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 transition-colors focus-visible:outline-none focus-visible:ring-2"
             >
               <X size={20} />
             </button>

--- a/frontend/components/dashboard/TechTreeNode.tsx
+++ b/frontend/components/dashboard/TechTreeNode.tsx
@@ -78,7 +78,8 @@ export default function TechTreeNode({
       <div className="flex items-center justify-between mt-4 gap-2">
         <button
           onClick={() => onToggle?.(skill.name)}
-          className={`flex-1 text-[10px] font-black uppercase tracking-widest py-2 rounded-xl transition-all ${
+          aria-label={isCompleted ? `Mark ${skill.name} as not mastered` : `Mark ${skill.name} as mastered`}
+          className={`flex-1 text-[10px] font-black uppercase tracking-widest py-2 rounded-xl transition-all focus-visible:outline-none focus-visible:ring-2 ${
             isCompleted
               ? "bg-emerald-500 text-white shadow-lg shadow-emerald-500/20"
               : "bg-white/60 text-slate-600"
@@ -89,12 +90,12 @@ export default function TechTreeNode({
 
         {skill.resources && skill.resources.length > 0 && (
           <div className="group/res relative">
-            <div className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400">
+            <button aria-label="View learning resources" className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400 focus-visible:outline-none focus-visible:ring-2">
               <ExternalLink size={14} />
-            </div>
+            </button>
 
             {/* Simple resources preview on hover */}
-            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible transition-all z-50 shadow-2xl">
+            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible group-focus-within/res:opacity-100 group-focus-within/res:visible transition-all z-50 shadow-2xl">
               <p className="font-black uppercase tracking-widest text-[#7C9ADD] mb-2">
                 Resources
               </p>

--- a/frontend/components/dashboard/VerticalRoadmap.tsx
+++ b/frontend/components/dashboard/VerticalRoadmap.tsx
@@ -118,7 +118,8 @@ function RoadmapNode({
               e.stopPropagation();
               onToggleStatus(skill.name);
             }}
-            className={`z-10 relative flex items-center justify-center w-10 h-10 rounded-full transition-all active:scale-90 ${
+            aria-label={skill.status === "completed" ? `Mark ${skill.name} as incomplete` : `Mark ${skill.name} as complete`}
+            className={`z-10 relative flex items-center justify-center w-10 h-10 rounded-full transition-all active:scale-90 focus-visible:outline-none focus-visible:ring-2 ${
               skill.status === "completed"
                 ? "bg-gradient-to-br from-emerald-400 to-teal-500 text-white shadow-lg shadow-emerald-500/30"
                 : "bg-slate-100 dark:bg-slate-800 text-slate-400 hover:text-indigo-500 hover:bg-indigo-50 dark:hover:bg-indigo-900/30"
@@ -188,7 +189,8 @@ function RoadmapNode({
                     e.stopPropagation();
                     setIsExpanded(!isExpanded);
                   }}
-                  className={`flex items-center gap-1 text-xs font-bold px-2 py-1 rounded-lg transition-colors ${
+                  aria-label={isExpanded ? `Collapse ${skill.name} modules` : `Expand ${skill.name} modules`}
+                  className={`flex items-center gap-1 text-xs font-bold px-2 py-1 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 ${
                     isExpanded
                       ? "text-indigo-600 bg-indigo-50 dark:bg-indigo-900/30"
                       : "text-slate-400 hover:text-slate-600 hover:bg-slate-100 dark:hover:bg-slate-800"


### PR DESCRIPTION
💡 What: Added ARIA labels and focus-visible rings to interactive elements in TechTreeNode, SkillDrawer, and VerticalRoadmap. Fixed hover-revealed tooltips to support keyboard focus via group-focus-within.
🎯 Why: Keyboard users and screen readers were unable to discover tooltips or understand the purpose of icon-only buttons like "Close" or "Toggle Mastery".
📸 Before/After: N/A (Visual changes only to focus states).
♿ Accessibility: Added `aria-label`, semantic `<button>` wrappers for triggers, and `focus-visible:ring-2` focus indicators across dashboard interactive elements.

---
*PR created automatically by Jules for task [2258659127979193996](https://jules.google.com/task/2258659127979193996) started by @SudoAnirudh*