### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack vulnerability in token validation

### DIFF
--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 import logging
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Security
@@ -69,7 +70,7 @@ async def trigger_jobs_sync(
     db=Depends(get_supabase_admin)
 ):
     expected_token = os.environ.get("JOBS_SYNC_TOKEN") or settings.jwt_secret
-    if not credentials or credentials.credentials != expected_token:
+    if not credentials or not secrets.compare_digest(credentials.credentials, expected_token):
         raise HTTPException(status_code=401, detail="Unauthorized.")
     try:
         new_jobs = await sync_twitter_jobs()


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `/sync` endpoint in `backend/routers/jobs_board.py` used standard equality operators (`!=`) for token string comparison. This exposed the API to timing attacks, where an attacker could deduce the token character-by-character based on the time it took to reject invalid comparisons.
🎯 **Impact:** An attacker could theoretically brute-force the sync token to trigger unauthorized job syncs or compromise the token itself if reused.
🔧 **Fix:** Replaced standard string comparison with constant-time `secrets.compare_digest`.
✅ **Verification:** Verify that the `/sync` endpoint still successfully authenticates requests with the valid token. Review the test suite to ensure existing endpoints function correctly. The `secrets` module is part of the standard library, so no new dependencies were added.

---
*PR created automatically by Jules for task [18374812375300187270](https://jules.google.com/task/18374812375300187270) started by @SudoAnirudh*