### PR TITLE
🎨 Palette: Make TechTreeNode resource tooltip keyboard accessible

### DIFF
--- a/frontend/app/dashboard/roadmap/page.tsx
+++ b/frontend/app/dashboard/roadmap/page.tsx
@@ -130,7 +130,7 @@ export default function RoadmapPage() {
 
     // Flatten all completed skills for the backend
     const getCompletedNames = (skills: RoadmapSkill[]): string[] => {
-      let names: string[] = [];
+      const names: string[] = [];
       skills.forEach((s) => {
         if (s.status === "completed") names.push(s.name);
         if (s.children) names.push(...getCompletedNames(s.children));

--- a/frontend/components/dashboard/TechTreeNode.tsx
+++ b/frontend/components/dashboard/TechTreeNode.tsx
@@ -89,12 +89,17 @@ export default function TechTreeNode({
 
         {skill.resources && skill.resources.length > 0 && (
           <div className="group/res relative">
-            <div className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400">
+            <button
+              type="button"
+              aria-label="View resources"
+              title="View resources"
+              className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none focus-visible:opacity-100"
+            >
               <ExternalLink size={14} />
-            </div>
+            </button>
 
             {/* Simple resources preview on hover */}
-            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible transition-all z-50 shadow-2xl">
+            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible group-focus-within/res:opacity-100 group-focus-within/res:visible transition-all z-50 shadow-2xl">
               <p className="font-black uppercase tracking-widest text-[#7C9ADD] mb-2">
                 Resources
               </p>


### PR DESCRIPTION
Replaced the icon-only trigger div with a semantic <button> and applied `focus-visible` styles to enable keyboard navigation. Updated the hover-revealed tooltip to also show on `group-focus-within`.

---
*PR created automatically by Jules for task [13862574172778609509](https://jules.google.com/task/13862574172778609509) started by @SudoAnirudh*