### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix timing attack vulnerability in token check

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-27 - [Timing Attack Vulnerability in Token Comparison]
+**Vulnerability:** Found a timing attack vulnerability in `backend/routers/jobs_board.py` where a security-sensitive string (authentication token) was compared using the standard equality operator (`!=`).
+**Learning:** Standard equality operators fail fast, which means the time it takes to compare two strings depends on how many characters match. This can allow an attacker to guess a secret token character by character based on the response time.
+**Prevention:** Always use `secrets.compare_digest` for comparing security-sensitive strings, API keys, or tokens in Python. This function performs a constant-time comparison, mitigating timing attacks.

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 import logging
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Security
@@ -69,7 +70,7 @@ async def trigger_jobs_sync(
     db=Depends(get_supabase_admin)
 ):
     expected_token = os.environ.get("JOBS_SYNC_TOKEN") or settings.jwt_secret
-    if not credentials or credentials.credentials != expected_token:
+    if not credentials or not secrets.compare_digest(credentials.credentials, expected_token):
         raise HTTPException(status_code=401, detail="Unauthorized.")
     try:
         new_jobs = await sync_twitter_jobs()


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix timing attack vulnerability

🚨 **Severity**: CRITICAL
💡 **Vulnerability**: A timing attack vulnerability was found in the `trigger_jobs_sync` endpoint inside `backend/routers/jobs_board.py` where a security-sensitive authentication token was being compared using the standard equality operator (`!=`). 
🎯 **Impact**: Using the standard equality operator allows an attacker to guess a secret token character-by-character based on the time it takes the comparison to fail (since it fails fast on the first mismatch).
🔧 **Fix**: Replaced the `!=` operator with `secrets.compare_digest()` which performs a constant-time comparison, mitigating the vulnerability.
✅ **Verification**: Run `cd backend && ruff check .` and `pytest` (with asyncio dependencies installed). Verified journal entry.

---
*PR created automatically by Jules for task [381301805770777973](https://jules.google.com/task/381301805770777973) started by @SudoAnirudh*