### PR TITLE
🎨 Palette: Fix broken hover and missing focus styles on Resume Editor toolbar

### DIFF
--- a/frontend/components/ResumeEditor.tsx
+++ b/frontend/components/ResumeEditor.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 
 const toolbarBtn =
-  "p-2 rounded-xl transition-all disabled:opacity-50 disabled:pointer-events-none #7C9ADD]/10 text-[#4A5568]";
+  "p-2 rounded-xl transition-all disabled:opacity-50 disabled:pointer-events-none hover:bg-[#7C9ADD]/10 focus-visible:ring-2 focus-visible:ring-[#7C9ADD] focus-visible:outline-none text-[#4A5568]";
 
 const MenuBar = ({
   editor,
@@ -51,7 +51,7 @@ const MenuBar = ({
   };
 
   const activeClass = "bg-[#7C9ADD]/10 text-[#7C9ADD] shadow-sm";
-  const idleClass = "text-[#718096] #7C9ADD]";
+  const idleClass = "text-[#718096] hover:text-[#7C9ADD]";
 
   return (
     <div className="flex flex-wrap items-center gap-1.5 p-3 sticky top-0 z-10 border-b border-white/60 bg-white/60 backdrop-blur-xl">
@@ -80,7 +80,7 @@ const MenuBar = ({
         <button
           onClick={() => editor.chain().focus().toggleBold().run()}
           disabled={!editor.can().chain().focus().toggleBold().run()}
-          className={`${toolbarBtn} ${editor.isActive("bold") ? "bg-[#7C9ADD]/10 text-[#7C9ADD] shadow-sm" : "text-[#718096] #7C9ADD]"}`}
+          className={`${toolbarBtn} ${editor.isActive("bold") ? "bg-[#7C9ADD]/10 text-[#7C9ADD] shadow-sm" : "text-[#718096] hover:text-[#7C9ADD]"}`}
           title="Bold"
           aria-label="Bold"
         >


### PR DESCRIPTION
💡 What: Fixed malformed arbitrary hex color class strings (e.g., `#7C9ADD]/10`) on the toolbar buttons in `frontend/components/ResumeEditor.tsx` by adding proper pseudo-class prefixes (`hover:bg-`, `hover:text-`) and added focus-visible states.

🎯 Why: The missing prefix caused broken class strings, resulting in missing interactive visual feedback (hover styles) which made the buttons feel unresponsive. Missing keyboard focus styles hurt accessibility.

📸 Before/After: Before, clicking or tabbing to toolbar buttons had no visible feedback ring and hover didn't correctly change color. After, buttons have clear background hover states and standard accessibility focus rings.

♿ Accessibility: Added `focus-visible:ring-2 focus-visible:ring-[#7C9ADD] focus-visible:outline-none` to `toolbarBtn` to ensure keyboard users have clear indication of which text formatting button is currently focused.

---
*PR created automatically by Jules for task [7282153393787275728](https://jules.google.com/task/7282153393787275728) started by @SudoAnirudh*