### PR TITLE
🎨 Palette: [UX improvement] Add ARIA label to SkillDrawer close button

### DIFF
--- a/frontend/app/dashboard/roadmap/page.tsx
+++ b/frontend/app/dashboard/roadmap/page.tsx
@@ -130,7 +130,7 @@ export default function RoadmapPage() {
 
     // Flatten all completed skills for the backend
     const getCompletedNames = (skills: RoadmapSkill[]): string[] => {
-      let names: string[] = [];
+      const names: string[] = [];
       skills.forEach((s) => {
         if (s.status === "completed") names.push(s.name);
         if (s.children) names.push(...getCompletedNames(s.children));

--- a/frontend/components/dashboard/SkillDrawer.tsx
+++ b/frontend/components/dashboard/SkillDrawer.tsx
@@ -51,7 +51,8 @@ export default function SkillDrawer({
             </h2>
             <button
               onClick={onClose}
-              className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 transition-colors"
+              aria-label="Close drawer"
+              className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 focus-visible:ring-2 focus-visible:outline-none transition-colors"
             >
               <X size={20} />
             </button>


### PR DESCRIPTION
## 💡 What
Added an explicit `aria-label="Close drawer"` and robust keyboard focus styles (`focus-visible:ring-2 focus-visible:outline-none`) to the icon-only "X" close button in the `SkillDrawer` component.

## 🎯 Why
Deeply nested components frequently miss basic accessibility attributes compared to top-level modals. The icon-only close button was a "silent" button for screen readers and lacked a visible focus indicator, making it inaccessible for non-mouse users navigating the nested UI.

## 📸 Before/After
*   **Before:** `<button onClick={onClose} className="p-2 rounded-full hover:bg-slate-100..."><X size={20} /></button>` (No screen reader context, no keyboard focus ring).
*   **After:** `<button onClick={onClose} aria-label="Close drawer" className="p-2 rounded-full hover:bg-slate-100... focus-visible:ring-2 focus-visible:outline-none"><X size={20} /></button>` (Clear screen reader context, clear keyboard focus ring).

## ♿ Accessibility
*   **Screen Readers:** The "X" icon is now clearly announced as "Close drawer" instead of being silent or unlabelled.
*   **Keyboard Navigation:** Users navigating via the `Tab` key will now see a clear `ring-2` focus state when the button is focused, allowing them to know exactly where they are before pressing `Enter` or `Space` to close the drawer.

---
*PR created automatically by Jules for task [5191938850540609867](https://jules.google.com/task/5191938850540609867) started by @SudoAnirudh*