### PR TITLE
🎨 Palette: Add accessibility attributes to SkillDrawer

### DIFF
--- a/frontend/app/dashboard/roadmap/page.tsx
+++ b/frontend/app/dashboard/roadmap/page.tsx
@@ -130,7 +130,7 @@ export default function RoadmapPage() {
 
     // Flatten all completed skills for the backend
     const getCompletedNames = (skills: RoadmapSkill[]): string[] => {
-      let names: string[] = [];
+      const names: string[] = [];
       skills.forEach((s) => {
         if (s.status === "completed") names.push(s.name);
         if (s.children) names.push(...getCompletedNames(s.children));

--- a/frontend/components/dashboard/SkillDrawer.tsx
+++ b/frontend/components/dashboard/SkillDrawer.tsx
@@ -51,7 +51,8 @@ export default function SkillDrawer({
             </h2>
             <button
               onClick={onClose}
-              className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 transition-colors"
+              aria-label="Close drawer"
+              className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
             >
               <X size={20} />
             </button>
@@ -123,7 +124,7 @@ export default function SkillDrawer({
                 onClick={() => {
                   onToggleStatus(skill.name);
                 }}
-                className={`w-full py-4 rounded-2xl font-bold flex items-center justify-center gap-2 transition-all ${
+                className={`w-full py-4 rounded-2xl font-bold flex items-center justify-center gap-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 ${
                   skill.status === "completed"
                     ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-800"
                     : "bg-indigo-600 text-white hover:bg-indigo-700 shadow-lg shadow-indigo-200 dark:shadow-none"


### PR DESCRIPTION
💡 What: Added an `aria-label` to the icon-only "Close" button and `focus-visible` ring styles to both the close button and the primary toggle action button in `SkillDrawer.tsx`.
🎯 Why: Deeply nested UI components frequently omit basic accessibility attributes and keyboard focus states compared to top-level modals. This ensures that screen reader users know what the icon-only button does and keyboard-only users can clearly see when these interactive elements have focus.
📸 Before/After: Visual focus rings are now prominent on these interactive elements when navigating via keyboard.
♿ Accessibility: Improved screen reader announcements for the close button and improved visual focus indicators for keyboard navigation.

---
*PR created automatically by Jules for task [9173145186279661325](https://jules.google.com/task/9173145186279661325) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for keyboard and assistive technology users.

* **Style**
  * Added visual focus indicators to interactive elements for clearer keyboard navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->