### PR TITLE
🎨 Palette: [UX improvement] Add focus states and aria-label to SkillDrawer

### DIFF
--- a/frontend/components/dashboard/SkillDrawer.tsx
+++ b/frontend/components/dashboard/SkillDrawer.tsx
@@ -51,7 +51,8 @@ export default function SkillDrawer({
             </h2>
             <button
               onClick={onClose}
-              className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 transition-colors"
+              aria-label="Close drawer"
+              className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
             >
               <X size={20} />
             </button>
@@ -82,7 +83,7 @@ export default function SkillDrawer({
                     href={resource.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-center gap-4 p-4 rounded-2xl bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700/50 hover:border-indigo-500 dark:hover:border-indigo-500 group transition-all"
+                    className="flex items-center gap-4 p-4 rounded-2xl bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700/50 hover:border-indigo-500 dark:hover:border-indigo-500 group transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
                   >
                     <div className="p-2.5 rounded-xl bg-white dark:bg-slate-900 shadow-sm text-indigo-500 group-hover:scale-110 transition-transform">
                       {resource.type === "video" ? (
@@ -123,7 +124,7 @@ export default function SkillDrawer({
                 onClick={() => {
                   onToggleStatus(skill.name);
                 }}
-                className={`w-full py-4 rounded-2xl font-bold flex items-center justify-center gap-2 transition-all ${
+                className={`w-full py-4 rounded-2xl font-bold flex items-center justify-center gap-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 ${
                   skill.status === "completed"
                     ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-800"
                     : "bg-indigo-600 text-white hover:bg-indigo-700 shadow-lg shadow-indigo-200 dark:shadow-none"


### PR DESCRIPTION
💡 What: Added an `aria-label` to the close button and `focus-visible` classes to all interactive elements (close button, resource links, status toggle) within the `SkillDrawer` component.
🎯 Why: To ensure screen reader users have context for icon-only buttons and to provide clear visual feedback for keyboard-only users navigating the deeply nested drawer component.
📸 Before/After: Before, keyboard navigation lacked focus rings on internal elements, and the close button was inaccessible to screen readers. After, robust outline rings indicate focus, and semantic labeling is present.
♿ Accessibility: Improved keyboard accessibility (WCAG 2.1.1 Keyboard) and screen reader support (WCAG 4.1.2 Name, Role, Value).

---
*PR created automatically by Jules for task [17470887021955359713](https://jules.google.com/task/17470887021955359713) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced keyboard navigation with improved visual focus indicators on interactive elements.
  * Strengthened visual feedback for the close button, learning resources, and action buttons during keyboard use.
  * Added descriptive labels for better accessibility and screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->