### PR TITLE
⚡ Bolt: Parallelize synchronous Supabase queries in job_suggester

### DIFF
--- a/backend/services/job_suggester.py
+++ b/backend/services/job_suggester.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import uuid
@@ -15,17 +16,26 @@ async def get_user_readiness_context(user_id: str, db) -> Dict[str, Any]:
     Synthesizes user profile, resume, interview, GitHub, and LinkedIn data for suggestion context.
     """
     try:
+        # ⚡ Bolt: Parallelize independent database queries
+        # What: Run resume, interviews, github, and linkedin queries concurrently.
+        # Why: The Supabase python client is synchronous. Running them sequentially takes 4x network round trips.
+        # Impact: Reduces query latency significantly by parallelizing independent reads.
+
         # 1. Latest Resume
-        resume_r = db.table("resumes").select("id, raw_text, ats_score").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+        resume_task = asyncio.to_thread(lambda: db.table("resumes").select("id, raw_text, ats_score").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
         
         # 2. Latest Interview Sessions
-        interviews_r = db.table("interview_sessions").select("id, overall_score, target_role").eq("user_id", user_id).order("created_at", desc=True).limit(3).execute()
+        interviews_task = asyncio.to_thread(lambda: db.table("interview_sessions").select("id, overall_score, target_role").eq("user_id", user_id).order("created_at", desc=True).limit(3).execute())
         
         # 3. GitHub Stats
-        github_r = db.table("github_analyses").select("gpi_score, strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+        github_task = asyncio.to_thread(lambda: db.table("github_analyses").select("gpi_score, strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
         
         # 4. LinkedIn Stats
-        linkedin_r = db.table("linkedin_analyses").select("strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+        linkedin_task = asyncio.to_thread(lambda: db.table("linkedin_analyses").select("strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
+
+        resume_r, interviews_r, github_r, linkedin_r = await asyncio.gather(
+            resume_task, interviews_task, github_task, linkedin_task
+        )
 
         ready_skills = []
 


### PR DESCRIPTION
💡 **What**: Refactored `get_user_readiness_context` in `backend/services/job_suggester.py` to use `asyncio.to_thread` and `asyncio.gather`.
🎯 **Why**: The Supabase Python client is synchronous. Running four independent database queries (resume, interviews, github, linkedin) sequentially in an async route blocks the event loop and incurs unnecessary sequential network latency.
📊 **Impact**: Reduces total database query latency for job suggestions by roughly 3-4x, parallelizing independent reads.
🔬 **Measurement**: Verify by calling the roadmap or suggestion generation endpoints; the time spent waiting for Supabase data should be visibly reduced in backend performance profiles.

Additionally, a critical learning regarding synchronous Supabase client calls inside async routes was recorded in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [1731186456142012580](https://jules.google.com/task/1731186456142012580) started by @SudoAnirudh*