### PR TITLE
🎨 Palette: [UX improvement] Add ARIA label and focus styles to SkillDrawer buttons

### DIFF
--- a/frontend/app/dashboard/roadmap/page.tsx
+++ b/frontend/app/dashboard/roadmap/page.tsx
@@ -130,7 +130,7 @@ export default function RoadmapPage() {
 
     // Flatten all completed skills for the backend
     const getCompletedNames = (skills: RoadmapSkill[]): string[] => {
-      let names: string[] = [];
+      const names: string[] = [];
       skills.forEach((s) => {
         if (s.status === "completed") names.push(s.name);
         if (s.children) names.push(...getCompletedNames(s.children));

--- a/frontend/components/dashboard/SkillDrawer.tsx
+++ b/frontend/components/dashboard/SkillDrawer.tsx
@@ -51,7 +51,8 @@ export default function SkillDrawer({
             </h2>
             <button
               onClick={onClose}
-              className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 transition-colors"
+              aria-label="Close skill details"
+              className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
             >
               <X size={20} />
             </button>
@@ -82,7 +83,7 @@ export default function SkillDrawer({
                     href={resource.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="flex items-center gap-4 p-4 rounded-2xl bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700/50 hover:border-indigo-500 dark:hover:border-indigo-500 group transition-all"
+                    className="flex items-center gap-4 p-4 rounded-2xl bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-700/50 hover:border-indigo-500 dark:hover:border-indigo-500 group transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
                   >
                     <div className="p-2.5 rounded-xl bg-white dark:bg-slate-900 shadow-sm text-indigo-500 group-hover:scale-110 transition-transform">
                       {resource.type === "video" ? (
@@ -123,7 +124,7 @@ export default function SkillDrawer({
                 onClick={() => {
                   onToggleStatus(skill.name);
                 }}
-                className={`w-full py-4 rounded-2xl font-bold flex items-center justify-center gap-2 transition-all ${
+                className={`w-full py-4 rounded-2xl font-bold flex items-center justify-center gap-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 focus-visible:ring-indigo-500 ${
                   skill.status === "completed"
                     ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-800"
                     : "bg-indigo-600 text-white hover:bg-indigo-700 shadow-lg shadow-indigo-200 dark:shadow-none"


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add ARIA label and focus styles to SkillDrawer buttons

💡 What:
- Added `aria-label="Close skill details"` to the 'X' close button in `SkillDrawer.tsx`.
- Added Tailwind `focus-visible` classes (e.g., `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500`) to the close button, the learning resource links, and the main "Mark as Completed" button.

🎯 Why:
- The icon-only close button lacked an accessible name, making it invisible to screen readers.
- Keyboard users had no clear visual indication of focus when tabbing through the interactive elements within the drawer, making navigation difficult.

📸 Before/After:
- Before: Icon buttons and links had standard hover states but no distinct keyboard focus rings.
- After: Elements now show a clear indigo focus ring when navigated via keyboard.

♿ Accessibility:
- Improves screen reader support for the close action.
- Ensures WCAG compliance for focus visibility (Criterion 2.4.7) on all interactive elements within the component.

---
*PR created automatically by Jules for task [5729147155849527866](https://jules.google.com/task/5729147155849527866) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced focus indicator visibility with improved ring and outline styling on dashboard components

* **Accessibility**
  * Added accessibility labels to close buttons and improved focus-visible styling on resource link cards and action toggle buttons for better keyboard navigation experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->