### PR TITLE
🎨 Palette: [UX improvement] Add aria-label and focus states to SkillDrawer

### DIFF
--- a/frontend/components/dashboard/SkillDrawer.tsx
+++ b/frontend/components/dashboard/SkillDrawer.tsx
@@ -51,7 +51,8 @@ export default function SkillDrawer({
             </h2>
             <button
               onClick={onClose}
-              className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 transition-colors"
+              aria-label="Close skill details"
+              className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none"
             >
               <X size={20} />
             </button>


### PR DESCRIPTION
💡 What: Added an `aria-label="Close skill details"` and proper `focus-visible` tailwind classes to the close button within the `SkillDrawer` nested component.
🎯 Why: Icon-only buttons lacking accessible names are difficult for screen reader users to understand. The missing focus states also made keyboard navigation less intuitive. Deeply nested components are often overlooked for these basic accessibility requirements.
📸 Before/After: Before, the button lacked an accessible name and keyboard focus styling. After, screen readers announce its purpose clearly, and keyboard users can visibly see when it is focused.
♿ Accessibility: Improved screen reader support and keyboard navigation for the `SkillDrawer` component.

---
*PR created automatically by Jules for task [12260133100020319657](https://jules.google.com/task/12260133100020319657) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility & Style**
  * Enhanced keyboard focus visibility on the skill details close button with improved styling indicators.
  * Improved screen reader support for the close button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->