### PR TITLE
🎨 Palette: Add accessibility to SkillDrawer close button

### DIFF
--- a/frontend/components/dashboard/SkillDrawer.tsx
+++ b/frontend/components/dashboard/SkillDrawer.tsx
@@ -51,7 +51,8 @@ export default function SkillDrawer({
             </h2>
             <button
               onClick={onClose}
-              className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 transition-colors"
+              aria-label="Close skill details"
+              className="p-2 rounded-full hover:bg-slate-100 dark:hover:bg-slate-800 text-slate-500 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 dark:focus-visible:ring-slate-500 dark:focus-visible:ring-offset-slate-900"
             >
               <X size={20} />
             </button>


### PR DESCRIPTION
💡 What: Added an `aria-label` and `focus-visible` Tailwind classes to the icon-only "Close" button in the `SkillDrawer` component.
🎯 Why: Deeply nested UI components often miss basic accessibility attributes. This ensures screen reader users understand the button's purpose and keyboard users have a clear visual focus indicator when navigating the component.
📸 Before/After: N/A (Visual change only visible on keyboard focus, adds ring).
♿ Accessibility: Improves WCAG compliance for non-text content (Name, Role, Value) and focus visibility.

---
*PR created automatically by Jules for task [1767659072444404000](https://jules.google.com/task/1767659072444404000) started by @SudoAnirudh*