### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and focus states to roadmap buttons

### DIFF
--- a/frontend/components/dashboard/VerticalRoadmap.tsx
+++ b/frontend/components/dashboard/VerticalRoadmap.tsx
@@ -118,7 +118,8 @@ function RoadmapNode({
               e.stopPropagation();
               onToggleStatus(skill.name);
             }}
-            className={`z-10 relative flex items-center justify-center w-10 h-10 rounded-full transition-all active:scale-90 ${
+            aria-label={`Toggle status for ${skill.name}`}
+            className={`z-10 relative flex items-center justify-center w-10 h-10 rounded-full transition-all active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 ${
               skill.status === "completed"
                 ? "bg-gradient-to-br from-emerald-400 to-teal-500 text-white shadow-lg shadow-emerald-500/30"
                 : "bg-slate-100 dark:bg-slate-800 text-slate-400 hover:text-indigo-500 hover:bg-indigo-50 dark:hover:bg-indigo-900/30"
@@ -188,7 +189,9 @@ function RoadmapNode({
                     e.stopPropagation();
                     setIsExpanded(!isExpanded);
                   }}
-                  className={`flex items-center gap-1 text-xs font-bold px-2 py-1 rounded-lg transition-colors ${
+                  aria-expanded={isExpanded}
+                  aria-label={isExpanded ? `Collapse ${skill.name} modules` : `Expand ${skill.name} modules`}
+                  className={`flex items-center gap-1 text-xs font-bold px-2 py-1 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 ${
                     isExpanded
                       ? "text-indigo-600 bg-indigo-50 dark:bg-indigo-900/30"
                       : "text-slate-400 hover:text-slate-600 hover:bg-slate-100 dark:hover:bg-slate-800"


### PR DESCRIPTION
💡 What: Added ARIA labels and `focus-visible` states to the status toggle and module expansion buttons in the VerticalRoadmap component.
🎯 Why: Deeply nested interactive components like roadmap nodes frequently lack proper accessibility attributes compared to top-level UI, hindering screen reader users and keyboard navigators.
📸 Before/After: Before, the buttons lacked accessible names and focus rings. After, they are explicitly labeled (e.g., "Toggle status for React", "Expand React modules") and feature visible focus outlines.
♿ Accessibility: Improves WCAG compliance by ensuring non-text buttons have accessible names and visual focus indicators for keyboard navigation.

---
*PR created automatically by Jules for task [12748167540891173014](https://jules.google.com/task/12748167540891173014) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation with clearer visual focus indicators on interactive controls.
  * Enhanced accessibility support with improved labeling for status toggles and module controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->