### PR TITLE
🎨 Palette: [UX improvement] Fix Resume Editor toolbar styling

### DIFF
--- a/frontend/components/ResumeEditor.tsx
+++ b/frontend/components/ResumeEditor.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 
 const toolbarBtn =
-  "p-2 rounded-xl transition-all disabled:opacity-50 disabled:pointer-events-none #7C9ADD]/10 text-[#4A5568]";
+  "p-2 rounded-xl transition-all disabled:opacity-50 disabled:pointer-events-none hover:bg-[#7C9ADD]/10 hover:text-[#7C9ADD] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#7C9ADD] text-[#4A5568]";
 
 const MenuBar = ({
   editor,
@@ -51,7 +51,7 @@ const MenuBar = ({
   };
 
   const activeClass = "bg-[#7C9ADD]/10 text-[#7C9ADD] shadow-sm";
-  const idleClass = "text-[#718096] #7C9ADD]";
+  const idleClass = "text-[#718096]";
 
   return (
     <div className="flex flex-wrap items-center gap-1.5 p-3 sticky top-0 z-10 border-b border-white/60 bg-white/60 backdrop-blur-xl">


### PR DESCRIPTION
💡 What: Fixed the dangling tailwind bracket syntax (e.g. `#7C9ADD]/10`) that was breaking the styling of the ResumeEditor toolbar buttons.
🎯 Why: The broken syntax was removing the hover state backgrounds and focus rings, resulting in poor visual feedback for interactive states and bad accessibility.
📸 Before/After: Visual update on the ResumeEditor toolbar (focus state added).
♿ Accessibility: The fix adds proper `focus-visible:ring-2` focus rings and hover state colors, greatly improving keyboard navigation accessibility and interaction feedback for these icon-only buttons.

---
*PR created automatically by Jules for task [447890900585493753](https://jules.google.com/task/447890900585493753) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected styling issues in the Resume Editor's toolbar buttons to ensure proper and consistent color rendering when buttons are inactive, hovered, or focused, improving visual clarity and interface consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->