### PR TITLE
🎨 Palette: [UX improvement] Fix keyboard navigation and screen reader a11y in VerticalRoadmap

### DIFF
--- a/frontend/components/dashboard/VerticalRoadmap.tsx
+++ b/frontend/components/dashboard/VerticalRoadmap.tsx
@@ -114,11 +114,12 @@ function RoadmapNode({
         {/* Status Indicator (Vibrant Circle) */}
         <div className="relative flex-shrink-0">
           <button
+            aria-label="Toggle status"
             onClick={(e) => {
               e.stopPropagation();
               onToggleStatus(skill.name);
             }}
-            className={`z-10 relative flex items-center justify-center w-10 h-10 rounded-full transition-all active:scale-90 ${
+            className={`z-10 relative flex items-center justify-center w-10 h-10 rounded-full transition-all active:scale-90 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${
               skill.status === "completed"
                 ? "bg-gradient-to-br from-emerald-400 to-teal-500 text-white shadow-lg shadow-emerald-500/30"
                 : "bg-slate-100 dark:bg-slate-800 text-slate-400 hover:text-indigo-500 hover:bg-indigo-50 dark:hover:bg-indigo-900/30"
@@ -139,7 +140,15 @@ function RoadmapNode({
 
         {/* Node Content */}
         <div
-          className="flex-1 cursor-pointer"
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onSkillClick(skill);
+            }
+          }}
+          className="flex-1 cursor-pointer focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none rounded-xl"
           onClick={() => onSkillClick(skill)}
         >
           <div className="flex items-start justify-between gap-4">
@@ -184,11 +193,12 @@ function RoadmapNode({
 
               {hasChildren && (
                 <button
+                  aria-expanded={isExpanded}
                   onClick={(e) => {
                     e.stopPropagation();
                     setIsExpanded(!isExpanded);
                   }}
-                  className={`flex items-center gap-1 text-xs font-bold px-2 py-1 rounded-lg transition-colors ${
+                  className={`flex items-center gap-1 text-xs font-bold px-2 py-1 rounded-lg transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none ${
                     isExpanded
                       ? "text-indigo-600 bg-indigo-50 dark:bg-indigo-900/30"
                       : "text-slate-400 hover:text-slate-600 hover:bg-slate-100 dark:hover:bg-slate-800"


### PR DESCRIPTION
💡 What
Added missing `aria-label`s, `focus-visible` styling, and full keyboard navigation support to the interactive elements within the `VerticalRoadmap` component.

🎯 Why
Deeply nested interactive components often miss essential accessibility markings, making it difficult for keyboard users to navigate (no focus rings) or screen reader users to understand the context (missing descriptive labels for icon-only buttons). 

📸 Before/After
Before: The status toggle button had no `aria-label`, the main roadmap node could not be activated via keyboard, and focus states were invisible.
After: The status toggle has an `aria-label`, the main node is fully keyboard accessible (`role="button"`, `tabIndex={0}`, `onKeyDown`), and all interactive areas display a clear `focus-visible:ring-2` to aid navigation.

♿ Accessibility
- Added `aria-label="Toggle status"` to the icon-only status toggle button.
- Made the `div` containing the Node Content keyboard focusable (`tabIndex={0}`) and interactable (`role="button"`, `onKeyDown` with Enter/Space handling).
- Added `aria-expanded` state tracking to the nested module accordion button.
- Ensured consistent and clear focus rings using Tailwind's `focus-visible` classes.

---
*PR created automatically by Jules for task [13512542678277308376](https://jules.google.com/task/13512542678277308376) started by @SudoAnirudh*