### PR TITLE
🎨 Palette: [UX improvement] Add focus visible state to ResumeEditor toolbar buttons

### DIFF
--- a/frontend/components/ResumeEditor.tsx
+++ b/frontend/components/ResumeEditor.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 
 const toolbarBtn =
-  "p-2 rounded-xl transition-all disabled:opacity-50 disabled:pointer-events-none #7C9ADD]/10 text-[#4A5568]";
+  "p-2 rounded-xl transition-all disabled:opacity-50 disabled:pointer-events-none hover:bg-[#7C9ADD]/10 focus-visible:ring-2 focus-visible:ring-[#7C9ADD] focus-visible:outline-none text-[#4A5568]";
 
 const MenuBar = ({
   editor,
@@ -50,8 +50,8 @@ const MenuBar = ({
     editor.chain().focus().extendMarkRange("link").setLink({ href: url }).run();
   };
 
-  const activeClass = "bg-[#7C9ADD]/10 text-[#7C9ADD] shadow-sm";
-  const idleClass = "text-[#718096] #7C9ADD]";
+  const activeClass = "bg-[#7C9ADD]/20 text-[#7C9ADD] shadow-sm";
+  const idleClass = "text-[#718096]";
 
   return (
     <div className="flex flex-wrap items-center gap-1.5 p-3 sticky top-0 z-10 border-b border-white/60 bg-white/60 backdrop-blur-xl">
@@ -80,7 +80,7 @@ const MenuBar = ({
         <button
           onClick={() => editor.chain().focus().toggleBold().run()}
           disabled={!editor.can().chain().focus().toggleBold().run()}
-          className={`${toolbarBtn} ${editor.isActive("bold") ? "bg-[#7C9ADD]/10 text-[#7C9ADD] shadow-sm" : "text-[#718096] #7C9ADD]"}`}
+          className={`${toolbarBtn} ${editor.isActive("bold") ? activeClass : idleClass}`}
           title="Bold"
           aria-label="Bold"
         >

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,16 @@
+1. **Analyze UX/a11y opportunities**:
+   - Looking at `frontend/components/ResumeEditor.tsx`, the `toolbarBtn` definition is missing focus visibility state for keyboard navigation accessibility.
+   - It is defined as: `const toolbarBtn = "p-2 rounded-xl transition-all disabled:opacity-50 disabled:pointer-events-none #7C9ADD]/10 text-[#4A5568]";`
+   - Adding `focus-visible:ring-2 focus-visible:ring-[#7C9ADD] focus-visible:outline-none` will make all the editor toolbar buttons keyboard accessible.
+   - This applies to 14 icon-only buttons in the ResumeEditor toolbar (bold, italic, list, alignment, undo, redo, link, heading 1, heading 2, etc.)
+
+2. **Implement change**:
+   - Update `toolbarBtn` in `frontend/components/ResumeEditor.tsx` to include `focus-visible:ring-2 focus-visible:ring-[#7C9ADD] focus-visible:outline-none`.
+
+3. **Verify change**:
+   - Run `cd frontend && pnpm lint` and `cd frontend && pnpm build` to verify nothing is broken.
+
+4. **Journaling**:
+   - Add journal entry to `.jules/palette.md` for learning about adding focus states to toolbar buttons.
+
+5. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done**.


### PR DESCRIPTION
💡 **What**: Added `focus-visible` ring styles to all toolbar icon buttons in the `ResumeEditor` component and fixed a malformed Tailwind CSS class (`#7C9ADD]/10`) to properly render hover states.

🎯 **Why**: The custom text editor's toolbar was inaccessible to keyboard users because it lacked visual feedback when navigating via the `Tab` key. Additionally, a typo in the class string broke the hover interaction styling.

📸 **Before/After**: Keyboard focus rings are now visibly apparent, and hover states apply the correct background color styling. (See attached verification screenshot)

♿ **Accessibility**: Significant improvement for keyboard users. Adding `focus-visible:ring-2 focus-visible:ring-[#7C9ADD] focus-visible:outline-none` allows standard browser keyboard navigation to function intuitively across the editor's 14 formatting buttons.

---
*PR created automatically by Jules for task [17222416843798637755](https://jules.google.com/task/17222416843798637755) started by @SudoAnirudh*