### PR TITLE
🎨 Palette: [UX improvement] Add keyboard accessibility to TechTreeNode buttons and tooltips

### DIFF
--- a/frontend/app/dashboard/roadmap/page.tsx
+++ b/frontend/app/dashboard/roadmap/page.tsx
@@ -130,7 +130,7 @@ export default function RoadmapPage() {
 
     // Flatten all completed skills for the backend
     const getCompletedNames = (skills: RoadmapSkill[]): string[] => {
-      let names: string[] = [];
+      const names: string[] = [];
       skills.forEach((s) => {
         if (s.status === "completed") names.push(s.name);
         if (s.children) names.push(...getCompletedNames(s.children));

--- a/frontend/components/dashboard/TechTreeNode.tsx
+++ b/frontend/components/dashboard/TechTreeNode.tsx
@@ -78,7 +78,7 @@ export default function TechTreeNode({
       <div className="flex items-center justify-between mt-4 gap-2">
         <button
           onClick={() => onToggle?.(skill.name)}
-          className={`flex-1 text-[10px] font-black uppercase tracking-widest py-2 rounded-xl transition-all ${
+          className={`flex-1 text-[10px] font-black uppercase tracking-widest py-2 rounded-xl transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
             isCompleted
               ? "bg-emerald-500 text-white shadow-lg shadow-emerald-500/20"
               : "bg-white/60 text-slate-600"
@@ -89,12 +89,22 @@ export default function TechTreeNode({
 
         {skill.resources && skill.resources.length > 0 && (
           <div className="group/res relative">
-            <div className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400">
+            <div
+              className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+              role="button"
+              tabIndex={0}
+              aria-label="View resources preview"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                }
+              }}
+            >
               <ExternalLink size={14} />
             </div>
 
             {/* Simple resources preview on hover */}
-            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible transition-all z-50 shadow-2xl">
+            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible group-focus-within/res:opacity-100 group-focus-within/res:visible transition-all z-50 shadow-2xl">
               <p className="font-black uppercase tracking-widest text-[#7C9ADD] mb-2">
                 Resources
               </p>


### PR DESCRIPTION
💡 What: Added keyboard accessibility to the "Mark Done" button and the ExternalLink resources preview tooltip in `TechTreeNode`.
🎯 Why: Custom hover tooltips on icon-only indicators are inaccessible to keyboard users because they lack focus visibility and keyboard interactions. This makes it impossible for users navigating by keyboard to see resource links.
📸 Before/After: Before, keyboard users could tab past the elements without any visual indicator or way to trigger the tooltip. After, they can tab to the button, see a clear focus ring, tab to the ExternalLink, see the focus ring, and trigger the tooltip.
♿ Accessibility: Added `focus-visible` classes, `tabIndex={0}`, `role="button"`, `onKeyDown` handler (to prevent scroll on space/enter), and `group-focus-within` to the tooltip container to ensure keyboard users can trigger and read the content.

---
*PR created automatically by Jules for task [12619429292689397471](https://jules.google.com/task/12619429292689397471) started by @SudoAnirudh*