### PR TITLE
⚡ Bolt: Use asyncio.gather for concurrent Supabase queries

### DIFF
--- a/backend/routers/roadmap.py
+++ b/backend/routers/roadmap.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException
@@ -28,7 +29,9 @@ async def get_current_roadmap(
     """Retrieve the user's latest saved roadmap and apply completed status."""
     try:
         user_id = user["user_id"]
-        res = db.table("roadmaps").select("*").eq("user_id", user_id).order("updated_at", desc=True).limit(1).execute()
+        res = await asyncio.to_thread(
+            lambda: db.table("roadmaps").select("*").eq("user_id", user_id).order("updated_at", desc=True).limit(1).execute()
+        )
         
         if not res.data:
             return None
@@ -58,9 +61,21 @@ async def generate_roadmap(
     try:
         user_id = user["user_id"]
         
+        # Fetch data concurrently
+        res_r_task = asyncio.to_thread(
+            lambda: db.table("resumes").select("raw_text").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+        )
+        gh_r_task = asyncio.to_thread(
+            lambda: db.table("github_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+        )
+        li_r_task = asyncio.to_thread(
+            lambda: db.table("linkedin_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+        )
+
+        res_r, gh_r, li_r = await asyncio.gather(res_r_task, gh_r_task, li_r_task)
+
         # 1. Fetch Resume
         resume_text = ""
-        res_r = db.table("resumes").select("raw_text").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
         if res_r.data:
             resume_text = res_r.data[0]["raw_text"]
         else:
@@ -68,13 +83,11 @@ async def generate_roadmap(
         
         # 2. Fetch GitHub
         gh_analysis = None
-        gh_r = db.table("github_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
         if gh_r.data:
             gh_analysis = gh_r.data[0]
             
         # 3. Fetch LinkedIn
         li_analysis = None
-        li_r = db.table("linkedin_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
         if li_r.data:
             li_analysis = li_r.data[0]
 
@@ -89,12 +102,14 @@ async def generate_roadmap(
         )
 
         # 5. Save to DB
-        db.table("roadmaps").insert({
-            "user_id": user_id,
-            "target_role": target_role,
-            "roadmap_data": roadmap.model_dump(),
-            "completed_skills": []
-        }).execute()
+        await asyncio.to_thread(
+            lambda: db.table("roadmaps").insert({
+                "user_id": user_id,
+                "target_role": target_role,
+                "roadmap_data": roadmap.model_dump(),
+                "completed_skills": []
+            }).execute()
+        )
 
         return roadmap
     except Exception as e:
@@ -114,9 +129,11 @@ async def update_skill_status(
         user_id = user["user_id"]
         
         # Update the latest roadmap for this user and role
-        res = db.table("roadmaps").update({
-            "completed_skills": update.completed_skills
-        }).eq("user_id", user_id).eq("target_role", update.target_role).execute()
+        res = await asyncio.to_thread(
+            lambda: db.table("roadmaps").update({
+                "completed_skills": update.completed_skills
+            }).eq("user_id", user_id).eq("target_role", update.target_role).execute()
+        )
         
         if not res.data:
             raise HTTPException(status_code=404, detail="Roadmap not found.")


### PR DESCRIPTION
- 💡 What: Used `asyncio.to_thread` to prevent the synchronous Supabase Python client from blocking the event loop in `backend/routers/roadmap.py` and implemented `asyncio.gather` for concurrent independent fetches.
- 🎯 Why: Using synchronous Supabase client in `async def` FastAPI routes was causing event loop blocking and poor performance. Sequential DB reads also caused unnecessary N+1 latency.
- 📊 Impact: Prevents blocking the event loop and reduces data fetch time for roadmaps by fetching data from 3 tables in parallel, making generation noticeably faster.
- 🔬 Measurement: Observe endpoint latency metrics and ensure roadmap endpoints handle concurrent load gracefully.

---
*PR created automatically by Jules for task [12556602619718749176](https://jules.google.com/task/12556602619718749176) started by @SudoAnirudh*