### PR TITLE
🎨 Palette: [UX improvement] Enhance accessibility of custom modal/panel icon buttons

### DIFF
--- a/frontend/components/InterviewPanel.tsx
+++ b/frontend/components/InterviewPanel.tsx
@@ -803,12 +803,13 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
             type="button"
             onClick={toggleListening}
             disabled={!speechSupported || submitting || transcribing}
-            className={`p-3.5 rounded-full transition-all active:scale-90 ${
+            className={`p-3.5 rounded-full transition-all active:scale-90 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-brand-blue ${
               isListening
                 ? "bg-red-500 hover:bg-red-600 text-white shadow-lg shadow-red-500/20"
                 : "bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
             } disabled:opacity-50`}
             title={isListening ? "Mute Microphone" : "Unmute Microphone"}
+            aria-label={isListening ? "Mute Microphone" : "Unmute Microphone"}
           >
             {isListening ? <Mic size={18} /> : <MicOff size={18} />}
           </button>
@@ -818,12 +819,13 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
             type="button"
             onClick={() => setCameraOn(!cameraOn)}
             disabled={submitting || transcribing}
-            className={`p-3.5 rounded-full transition-all active:scale-90 ${
+            className={`p-3.5 rounded-full transition-all active:scale-90 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-brand-blue ${
               cameraOn
                 ? "bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
                 : "bg-red-500 hover:bg-red-600 text-white shadow-lg shadow-red-500/20"
             }`}
             title={cameraOn ? "Stop Video" : "Start Video"}
+            aria-label={cameraOn ? "Stop Video" : "Start Video"}
           >
             {cameraOn ? <Video size={18} /> : <VideoOff size={18} />}
           </button>
@@ -854,8 +856,9 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
             <button
               type="button"
               onClick={onExit}
-              className="p-3.5 rounded-full bg-slate-800 hover:bg-slate-700 text-red-400 border border-slate-700 transition-all active:scale-90"
+              className="p-3.5 rounded-full bg-slate-800 hover:bg-slate-700 text-red-400 border border-slate-700 transition-all active:scale-90 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-brand-blue"
               title="Hang Up / Exit Interview"
+              aria-label="Hang Up / Exit Interview"
             >
               <PhoneOff size={18} />
             </button>

--- a/frontend/components/OutreachModal.tsx
+++ b/frontend/components/OutreachModal.tsx
@@ -104,7 +104,7 @@ export default function OutreachModal({
           <button
             onClick={onClose}
             aria-label="Close modal"
-            className="w-12 h-12 rounded-2xl #F1F5F9] flex items-center justify-center text-[#A0AEC0] transition-colors"
+            className="w-12 h-12 rounded-2xl #F1F5F9] flex items-center justify-center text-[#A0AEC0] transition-colors focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-slate-400"
           >
             <X size={24} />
           </button>
@@ -115,7 +115,7 @@ export default function OutreachModal({
           <div className="w-full md:w-64 bg-[#F8FAFC] border-r border-[#F1F5F9] p-6 space-y-4">
             <button
               onClick={() => setActiveTab("linkedin")}
-              className={`w-full p-4 rounded-2xl flex items-center gap-3 transition-all ${
+              className={`w-full p-4 rounded-2xl flex items-center gap-3 transition-all focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-[#0A66C2] ${
                 activeTab === "linkedin"
                   ? "bg-white shadow-lg text-[#0A66C2] border border-[#0A66C2]/10"
                   : "text-[#718096]"
@@ -128,7 +128,7 @@ export default function OutreachModal({
             </button>
             <button
               onClick={() => setActiveTab("email")}
-              className={`w-full p-4 rounded-2xl flex items-center gap-3 transition-all ${
+              className={`w-full p-4 rounded-2xl flex items-center gap-3 transition-all focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-[#6366F1] ${
                 activeTab === "email"
                   ? "bg-white shadow-lg text-[#6366F1] border border-[#6366F1]/10"
                   : "text-[#718096]"


### PR DESCRIPTION
💡 What: Added `aria-label`s to the Mic, Camera, and Hang Up buttons in `InterviewPanel.tsx`, and added `focus-visible` ring styling to those buttons as well as the tabs and close button in `OutreachModal.tsx`.
🎯 Why: To improve keyboard navigation and screen-reader accessibility for heavily-used custom modal/panel components that bypassed standard Button accessibility features.
📸 Before/After: Visual outline now appears when tabbing to these buttons.
♿ Accessibility: Ensures non-mouse users can clearly identify focus and screen readers announce the purpose of icon-only action toggles.

---
*PR created automatically by Jules for task [9797252655852803538](https://jules.google.com/task/9797252655852803538) started by @SudoAnirudh*