### PR TITLE
⚡ Bolt: [performance improvement] Concurrent Supabase Queries

### DIFF
--- a/backend/routers/roadmap.py
+++ b/backend/routers/roadmap.py
@@ -1,4 +1,5 @@
 import logging
+import asyncio
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException
 from models.roadmap import CareerRoadmap, RoadmapUpdate
@@ -58,9 +59,15 @@ async def generate_roadmap(
     try:
         user_id = user["user_id"]
         
+        # Fetch resume and analysis data concurrently
+        resume_task = asyncio.to_thread(lambda: db.table("resumes").select("raw_text").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
+        gh_task = asyncio.to_thread(lambda: db.table("github_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
+        li_task = asyncio.to_thread(lambda: db.table("linkedin_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
+
+        res_r, gh_r, li_r = await asyncio.gather(resume_task, gh_task, li_task)
+
         # 1. Fetch Resume
         resume_text = ""
-        res_r = db.table("resumes").select("raw_text").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
         if res_r.data:
             resume_text = res_r.data[0]["raw_text"]
         else:
@@ -68,13 +75,11 @@ async def generate_roadmap(
         
         # 2. Fetch GitHub
         gh_analysis = None
-        gh_r = db.table("github_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
         if gh_r.data:
             gh_analysis = gh_r.data[0]
             
         # 3. Fetch LinkedIn
         li_analysis = None
-        li_r = db.table("linkedin_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
         if li_r.data:
             li_analysis = li_r.data[0]
 

--- a/backend/services/job_suggester.py
+++ b/backend/services/job_suggester.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import uuid
+import asyncio
 from typing import Dict, Any
 
 from services.job_scraper import scrape_jobs
@@ -15,17 +16,13 @@ async def get_user_readiness_context(user_id: str, db) -> Dict[str, Any]:
     Synthesizes user profile, resume, interview, GitHub, and LinkedIn data for suggestion context.
     """
     try:
-        # 1. Latest Resume
-        resume_r = db.table("resumes").select("id, raw_text, ats_score").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
-        
-        # 2. Latest Interview Sessions
-        interviews_r = db.table("interview_sessions").select("id, overall_score, target_role").eq("user_id", user_id).order("created_at", desc=True).limit(3).execute()
-        
-        # 3. GitHub Stats
-        github_r = db.table("github_analyses").select("gpi_score, strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
-        
-        # 4. LinkedIn Stats
-        linkedin_r = db.table("linkedin_analyses").select("strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+        # Fetch data concurrently
+        resume_task = asyncio.to_thread(lambda: db.table("resumes").select("id, raw_text, ats_score").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
+        interviews_task = asyncio.to_thread(lambda: db.table("interview_sessions").select("id, overall_score, target_role").eq("user_id", user_id).order("created_at", desc=True).limit(3).execute())
+        github_task = asyncio.to_thread(lambda: db.table("github_analyses").select("gpi_score, strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
+        linkedin_task = asyncio.to_thread(lambda: db.table("linkedin_analyses").select("strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
+
+        resume_r, interviews_r, github_r, linkedin_r = await asyncio.gather(resume_task, interviews_task, github_task, linkedin_task)
 
         ready_skills = []
 


### PR DESCRIPTION
💡 What: Refactored multiple sequential, synchronous Supabase `db.table(...).execute()` calls to use `asyncio.to_thread` and `asyncio.gather`.
🎯 Why: The synchronous Supabase Python client blocks the FastAPI event loop during I/O. By fetching independent data sources sequentially, the endpoints suffered from N+1 latency bottlenecks. Moving them to threads and gathering them concurrently significantly reduces endpoint latency and prevents event loop blocking.
📊 Impact: Reduces the latency of the `/generate` roadmap endpoint and the job suggestion engine by changing total query time from `O(T1 + T2 + T3)` to `O(max(T1, T2, T3))`.
🔬 Measurement: Verify by running `pytest` locally and observing the TTFB (Time to First Byte) in network tools when hitting these endpoints before and after the change.

---
*PR created automatically by Jules for task [17482218651933963071](https://jules.google.com/task/17482218651933963071) started by @SudoAnirudh*