### PR TITLE
🎨 Palette: Improve accessibility in TechTree Node resources

### DIFF
--- a/frontend/app/dashboard/roadmap/page.tsx
+++ b/frontend/app/dashboard/roadmap/page.tsx
@@ -130,7 +130,7 @@ export default function RoadmapPage() {
 
     // Flatten all completed skills for the backend
     const getCompletedNames = (skills: RoadmapSkill[]): string[] => {
-      let names: string[] = [];
+      const names: string[] = [];
       skills.forEach((s) => {
         if (s.status === "completed") names.push(s.name);
         if (s.children) names.push(...getCompletedNames(s.children));

--- a/frontend/components/dashboard/TechTreeNode.tsx
+++ b/frontend/components/dashboard/TechTreeNode.tsx
@@ -89,12 +89,15 @@ export default function TechTreeNode({
 
         {skill.resources && skill.resources.length > 0 && (
           <div className="group/res relative">
-            <div className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400">
+            <button
+              aria-label="View resources"
+              className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            >
               <ExternalLink size={14} />
-            </div>
+            </button>
 
             {/* Simple resources preview on hover */}
-            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible transition-all z-50 shadow-2xl">
+            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible group-focus-within/res:opacity-100 group-focus-within/res:visible transition-all z-50 shadow-2xl">
               <p className="font-black uppercase tracking-widest text-[#7C9ADD] mb-2">
                 Resources
               </p>


### PR DESCRIPTION
💡 **What**
Added proper accessibility and keyboard navigation attributes to the resource preview trigger within `TechTreeNode.tsx`.

🎯 **Why**
The original implementation used an icon-only `<div className="cursor-pointer">` which lacked native keyboard focusability, an accessible name for screen readers, and a visible focus state. Additionally, the nested custom hover tooltip (`group-hover`) would not appear for users relying on keyboard navigation, hiding critical learning resources.

📸 **Before/After**
- **Before:** Keyboard users could not tab to the resource external link trigger, nor view the resource tooltip.
- **After:** The resource button is reachable via tab, displays a clear focus ring, announces its purpose via `aria-label`, and the tooltip properly appears on keyboard focus.

♿ **Accessibility**
- Converted `div` to `button` for native keyboard/tab indexing.
- Added `aria-label="View resources"` for screen readers.
- Added Tailwind `focus-visible:ring-2` to visually indicate keyboard focus.
- Added Tailwind `group-focus-within` to the tooltip container to expose the preview for keyboard users.

---
*PR created automatically by Jules for task [18237920303882464490](https://jules.google.com/task/18237920303882464490) started by @SudoAnirudh*