### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix path traversal risk in temporary file creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** User input was being directly interpolated into Supabase PostgREST `.or_()` clauses.
 **Learning:** Commas and parentheses in strings are interpreted as syntactic boundaries in PostgREST filters, leading to injection vulnerabilities.
 **Prevention:** Added a `sanitize_postgrest_filter` utility function to strip out commas, parentheses, and double-quotes from user input before usage in these clauses.
+
+## 2025-02-28 - Hardcoded /tmp/ path vulnerability
+**Vulnerability:** Hardcoded `/tmp/` path for temporary file creation.
+**Learning:** Hardcoding `/tmp/` can lead to path traversal vulnerabilities, file collision/overwrite, or failure on systems where the temporary directory is different (like Windows or environments with specific TMPDIR setups), as well as failure when `cleanup_temp` expects `tempfile.gettempdir()`.
+**Prevention:** Always use `tempfile.gettempdir()` combined with `os.path.join()` or use `tempfile.NamedTemporaryFile` to securely manage temporary files in a cross-platform and secure manner.

--- a/backend/utils/file_handler.py
+++ b/backend/utils/file_handler.py
@@ -7,10 +7,10 @@ from fastapi import UploadFile
 import uuid
 
 async def save_upload_temp(file: UploadFile) -> str:
-    """Save an uploaded file to /tmp and return the temp path."""
+    """Save an uploaded file to a temporary directory and return the temp path."""
     safe_filename = os.path.basename(file.filename)
     unique_filename = f"{uuid.uuid4()}_{safe_filename}"
-    tmp_path = f"/tmp/{unique_filename}"
+    tmp_path = os.path.join(tempfile.gettempdir(), unique_filename)
     content = await file.read()
     async with aiofiles.open(tmp_path, "wb") as f:
         await f.write(content)


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Hardcoded `/tmp/` path for temporary file creation in `backend/utils/file_handler.py`.
🎯 **Impact**: Hardcoding `/tmp/` can lead to path traversal vulnerabilities, file collision/overwrite, or failure on systems where the temporary directory is different (like Windows or environments with specific TMPDIR setups), as well as failure when `cleanup_temp` expects `tempfile.gettempdir()`.
🔧 **Fix**: Replaced the hardcoded `/tmp/` path with `os.path.join(tempfile.gettempdir(), ...)` to dynamically resolve the secure system temporary directory.
✅ **Verification**: Run backend tests (`PYTHONPATH=backend pytest backend/tests/`) and frontend lint checks to ensure no regressions.

---
*PR created automatically by Jules for task [4786836431600947568](https://jules.google.com/task/4786836431600947568) started by @SudoAnirudh*