### PR TITLE
⚡ Bolt: Parallelize synchronous Supabase queries

### DIFF
--- a/backend/routers/roadmap.py
+++ b/backend/routers/roadmap.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException
@@ -58,23 +59,30 @@ async def generate_roadmap(
     try:
         user_id = user["user_id"]
         
-        # 1. Fetch Resume
+        # ⚡ Bolt: Parallelize independent database queries
+        # What: Uses asyncio.gather with asyncio.to_thread to run 3 Supabase queries concurrently.
+        # Why: The Supabase python client is synchronous; calling .execute() in series blocks the async event loop and increases latency.
+        # Impact: Reduces query time from ~3N to ~1N, significantly speeding up the roadmap generation process.
+        resume_task = asyncio.to_thread(lambda: db.table("resumes").select("raw_text").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
+        github_task = asyncio.to_thread(lambda: db.table("github_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
+        linkedin_task = asyncio.to_thread(lambda: db.table("linkedin_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
+
+        res_r, gh_r, li_r = await asyncio.gather(resume_task, github_task, linkedin_task)
+
+        # 1. Check Resume
         resume_text = ""
-        res_r = db.table("resumes").select("raw_text").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
         if res_r.data:
             resume_text = res_r.data[0]["raw_text"]
         else:
             raise HTTPException(status_code=400, detail="No resume found. Please upload a resume first.")
         
-        # 2. Fetch GitHub
+        # 2. Check GitHub
         gh_analysis = None
-        gh_r = db.table("github_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
         if gh_r.data:
             gh_analysis = gh_r.data[0]
             
-        # 3. Fetch LinkedIn
+        # 3. Check LinkedIn
         li_analysis = None
-        li_r = db.table("linkedin_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
         if li_r.data:
             li_analysis = li_r.data[0]
 

--- a/backend/services/job_suggester.py
+++ b/backend/services/job_suggester.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import uuid
@@ -15,17 +16,18 @@ async def get_user_readiness_context(user_id: str, db) -> Dict[str, Any]:
     Synthesizes user profile, resume, interview, GitHub, and LinkedIn data for suggestion context.
     """
     try:
-        # 1. Latest Resume
-        resume_r = db.table("resumes").select("id, raw_text, ats_score").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
-        
-        # 2. Latest Interview Sessions
-        interviews_r = db.table("interview_sessions").select("id, overall_score, target_role").eq("user_id", user_id).order("created_at", desc=True).limit(3).execute()
-        
-        # 3. GitHub Stats
-        github_r = db.table("github_analyses").select("gpi_score, strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
-        
-        # 4. LinkedIn Stats
-        linkedin_r = db.table("linkedin_analyses").select("strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+        # ⚡ Bolt: Parallelize independent database queries
+        # What: Uses asyncio.gather with asyncio.to_thread to run 4 Supabase queries concurrently.
+        # Why: The Supabase python client is synchronous; calling .execute() in series blocks the async event loop and increases latency.
+        # Impact: Reduces query time from ~4N to ~1N, significantly speeding up the readiness context generation.
+        resume_task = asyncio.to_thread(lambda: db.table("resumes").select("id, raw_text, ats_score").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
+        interviews_task = asyncio.to_thread(lambda: db.table("interview_sessions").select("id, overall_score, target_role").eq("user_id", user_id).order("created_at", desc=True).limit(3).execute())
+        github_task = asyncio.to_thread(lambda: db.table("github_analyses").select("gpi_score, strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
+        linkedin_task = asyncio.to_thread(lambda: db.table("linkedin_analyses").select("strengths").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
+
+        resume_r, interviews_r, github_r, linkedin_r = await asyncio.gather(
+            resume_task, interviews_task, github_task, linkedin_task
+        )
 
         ready_skills = []
 


### PR DESCRIPTION
💡 What: Replaced sequential `db.table(...).execute()` calls with `asyncio.gather(asyncio.to_thread(...))` in `backend/services/job_suggester.py` and `backend/routers/roadmap.py`.
🎯 Why: The Supabase Python client's `.execute()` calls are synchronous. Calling them sequentially inside an `async def` function blocks the async event loop and creates an N+1 latency bottleneck.
📊 Impact: Reduces query time from ~3N/4N to ~1N, significantly speeding up the readiness context and roadmap generation endpoints while unblocking the event loop for higher overall application throughput.
🔬 Measurement: Verified backend functionality via `pytest tests/` and frontend via `pnpm lint` & `pnpm build`. Added a journal entry to document the `asyncio.to_thread` pattern for Supabase queries.

---
*PR created automatically by Jules for task [5679902266784601029](https://jules.google.com/task/5679902266784601029) started by @SudoAnirudh*