### PR TITLE
🎨 Palette: Improve keyboard accessibility in TechTreeNode

### DIFF
--- a/frontend/components/dashboard/TechTreeNode.tsx
+++ b/frontend/components/dashboard/TechTreeNode.tsx
@@ -78,7 +78,7 @@ export default function TechTreeNode({
       <div className="flex items-center justify-between mt-4 gap-2">
         <button
           onClick={() => onToggle?.(skill.name)}
-          className={`flex-1 text-[10px] font-black uppercase tracking-widest py-2 rounded-xl transition-all ${
+          className={`flex-1 text-[10px] font-black uppercase tracking-widest py-2 rounded-xl transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
             isCompleted
               ? "bg-emerald-500 text-white shadow-lg shadow-emerald-500/20"
               : "bg-white/60 text-slate-600"
@@ -89,12 +89,16 @@ export default function TechTreeNode({
 
         {skill.resources && skill.resources.length > 0 && (
           <div className="group/res relative">
-            <div className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400">
+            <div
+              tabIndex={0}
+              aria-label="View resources preview"
+              className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            >
               <ExternalLink size={14} />
             </div>
 
             {/* Simple resources preview on hover */}
-            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible transition-all z-50 shadow-2xl">
+            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible group-focus-within/res:opacity-100 group-focus-within/res:visible transition-all z-50 shadow-2xl">
               <p className="font-black uppercase tracking-widest text-[#7C9ADD] mb-2">
                 Resources
               </p>

--- a/frontend/tests/test_components.test.tsx
+++ b/frontend/tests/test_components.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import TechTreeNode from '../components/dashboard/TechTreeNode';
+
+describe('TechTreeNode Accessibility', () => {
+  it('renders resources trigger with correct aria attributes and tabIndex', () => {
+    const mockSkill = {
+      name: 'React',
+      status: 'completed',
+      priority: 'high',
+      estimated_time: '2h',
+      description: 'Test',
+      resources: [{ title: 'Resource 1', url: '#', type: 'article' }]
+    };
+
+    render(<TechTreeNode skill={mockSkill as any} index={0} />);
+
+    const trigger = screen.getByLabelText('View resources preview');
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('tabIndex', '0');
+    expect(trigger).toHaveClass('focus-visible:outline-none');
+    expect(trigger).toHaveClass('focus-visible:ring-2');
+  });
+
+  it('renders Mark Done button with focus-visible classes', () => {
+     const mockSkill = {
+      name: 'React',
+      status: 'in_progress',
+      priority: 'high',
+      estimated_time: '2h',
+      description: 'Test',
+      resources: []
+    };
+
+    render(<TechTreeNode skill={mockSkill as any} index={0} />);
+
+    const markDoneBtn = screen.getByRole('button', { name: /Mark Done/i });
+    expect(markDoneBtn).toBeInTheDocument();
+    expect(markDoneBtn).toHaveClass('focus-visible:outline-none');
+  });
+});


### PR DESCRIPTION
💡 What: Added keyboard navigation support and focus states to the "Mark Done" button and the resource tooltip trigger within the `TechTreeNode` component.
🎯 Why: Previously, users relying on keyboard navigation could not access the resource list preview or clearly see which element had focus in the `TechTreeNode`, negatively impacting the learning experience.
📸 Before/After: Visual focus rings are now apparent when navigating via keyboard, and the resources tooltip displays correctly on focus.
♿ Accessibility:
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500` to interactive elements.
- Added `tabIndex={0}` and `aria-label="View resources preview"` to the icon-only resource trigger `div`.
- Added `group-focus-within/res:opacity-100 group-focus-within/res:visible` to the tooltip container to ensure visibility on keyboard focus.

---
*PR created automatically by Jules for task [14690059293548570506](https://jules.google.com/task/14690059293548570506) started by @SudoAnirudh*