### PR TITLE
🎨 Palette: Add keyboard accessibility to TechTreeNode tooltips

### DIFF
--- a/frontend/components/dashboard/TechTreeNode.tsx
+++ b/frontend/components/dashboard/TechTreeNode.tsx
@@ -78,7 +78,7 @@ export default function TechTreeNode({
       <div className="flex items-center justify-between mt-4 gap-2">
         <button
           onClick={() => onToggle?.(skill.name)}
-          className={`flex-1 text-[10px] font-black uppercase tracking-widest py-2 rounded-xl transition-all ${
+          className={`flex-1 text-[10px] font-black uppercase tracking-widest py-2 rounded-xl transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${
             isCompleted
               ? "bg-emerald-500 text-white shadow-lg shadow-emerald-500/20"
               : "bg-white/60 text-slate-600"
@@ -89,12 +89,16 @@ export default function TechTreeNode({
 
         {skill.resources && skill.resources.length > 0 && (
           <div className="group/res relative">
-            <div className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400">
+            <div
+              tabIndex={0}
+              aria-label="View resources"
+              className="p-2 rounded-xl bg-white/40 border border-white transition-colors cursor-pointer text-slate-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            >
               <ExternalLink size={14} />
             </div>
 
             {/* Simple resources preview on hover */}
-            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible transition-all z-50 shadow-2xl">
+            <div className="absolute bottom-full right-0 mb-3 w-48 bg-slate-900 text-white p-3 rounded-2xl text-[10px] opacity-0 invisible group-hover/res:opacity-100 group-hover/res:visible group-focus-within/res:opacity-100 group-focus-within/res:visible transition-all z-50 shadow-2xl">
               <p className="font-black uppercase tracking-widest text-[#7C9ADD] mb-2">
                 Resources
               </p>


### PR DESCRIPTION
💡 What: Added keyboard accessibility to the "Mark Done" button and the Resources tooltip in the TechTreeNode component.

🎯 Why: Keyboard users could not access the hover-based tooltip revealing resources, and the "Mark Done" button lacked visible focus states.

📸 Before/After: The resources tooltip is now accessible via keyboard focus on the ExternalLink icon, and buttons have clear focus rings.

♿ Accessibility: Added `focus-visible` styles, `tabIndex={0}`, `aria-label`, and `group-focus-within` classes to ensure screen reader and keyboard navigation work as intended.

---
*PR created automatically by Jules for task [7208008837906980839](https://jules.google.com/task/7208008837906980839) started by @SudoAnirudh*