### PR TITLE
⚡ Bolt: [performance improvement] Parallelize cover letter export queries

### DIFF
--- a/backend/routers/cover_letter.py
+++ b/backend/routers/cover_letter.py
@@ -1,5 +1,6 @@
 import uuid
 import datetime
+import asyncio
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from dependencies import get_current_user, get_supabase_admin
@@ -93,25 +94,30 @@ async def export_cover_letter(
     db=Depends(get_supabase_admin),
 ):
     """Exports a cover letter as PDF or Docx."""
-    r = (
-        db.table("cover_letters")
+    # ⚡ Bolt: Parallelize independent database queries during export
+    # What: Replaced sequential blocking Supabase calls with concurrent thread execution using asyncio.gather.
+    # Why: The synchronous python Supabase client calls `.execute()` serially, which blocks the async event loop and increases latency when assembling the export data.
+    # Impact: Reduces query overhead for cover letter generation from ~2N to ~1N, making PDF/Docx downloads snappier.
+    cover_letter_task = asyncio.to_thread(
+        lambda: db.table("cover_letters")
         .select("*")
         .eq("id", letter_id)
         .eq("user_id", user["user_id"])
         .single()
         .execute()
     )
-    if not r.data:
-        raise HTTPException(status_code=404, detail="Cover letter not found.")
-
-    # Fetch user profile for headers
-    p = (
-        db.table("profiles")
+    profile_task = asyncio.to_thread(
+        lambda: db.table("profiles")
         .select("full_name")
         .eq("id", user["user_id"])
         .single()
         .execute()
     )
+
+    r, p = await asyncio.gather(cover_letter_task, profile_task)
+
+    if not r.data:
+        raise HTTPException(status_code=404, detail="Cover letter not found.")
     
     header_info = {
         "name": p.data.get("full_name", "Valued User"),


### PR DESCRIPTION
💡 What: Replaced sequential blocking Supabase `.execute()` calls with `asyncio.gather(asyncio.to_thread(...))` in the cover letter export router.
🎯 Why: The synchronous Python Supabase client calls blocked the async event loop in FastAPI, causing unnecessary delay and impacting concurrent throughput during the export generation process.
📊 Impact: Reduces database query overhead from 2 network roundtrips sequentially to roughly the maximum time of 1 roundtrip, making PDF and Docx downloads significantly snappier while freeing up the main event loop.
🔬 Measurement: Check the network tab on cover letter export or observe timing metrics in backend logs; overall endpoint latency is reduced.

---
*PR created automatically by Jules for task [3929878577664834012](https://jules.google.com/task/3929878577664834012) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export reliability by returning a clear “not found” response when a cover letter doesn’t exist.
  * Made cover letter export faster by loading required profile data in parallel instead of one after another.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->