### PR TITLE
⚡ Bolt: Optimize /scrape-jobs database query concurrency

### DIFF
--- a/backend/routers/job_match.py
+++ b/backend/routers/job_match.py
@@ -158,9 +158,10 @@ async def scrape_jobs_for_fields(
     if not fields:
         raise HTTPException(status_code=400, detail="At least one field is required.")
 
-    # 1. Scrape jobs
+    # 1 & 2. Scrape jobs and fetch resume concurrently
     limit = max(1, min(payload.limit, 50))
-    jobs = await scrape_jobs(
+
+    scrape_task = scrape_jobs(
         fields,
         payload.location,
         payload.remote_only,
@@ -169,9 +170,8 @@ async def scrape_jobs_for_fields(
         payload.job_type or "any"
     )
     
-    # 2. Fetch user's latest resume for auto-matching
-    r = (
-        db.table("resumes")
+    resume_task = asyncio.to_thread(
+        lambda: db.table("resumes")
         .select("raw_text")
         .eq("user_id", user["user_id"])
         .order("created_at", desc=True)
@@ -179,6 +179,8 @@ async def scrape_jobs_for_fields(
         .execute()
     )
     
+    jobs, r = await asyncio.gather(scrape_task, resume_task)
+
     if r.data:
         resume_text = r.data[0]["raw_text"]
         


### PR DESCRIPTION
💡 What: Refactored `scrape_jobs_for_fields` in `backend/routers/job_match.py` to fetch the user's resume from the database concurrently with the web scraping task using `asyncio.gather` and `asyncio.to_thread`.
🎯 Why: The Supabase Python client's `.execute()` method is synchronous. Previously, it was running sequentially after a potentially slow async network call (`scrape_jobs`), adding unnecessary latency. Overlapping these operations reduces the total endpoint response time.
📊 Impact: Reduces total latency by overlapping database I/O with network I/O.
🔬 Measurement: Endpoint response time can be measured and compared.

---
*PR created automatically by Jules for task [9027495568286029288](https://jules.google.com/task/9027495568286029288) started by @SudoAnirudh*