### PR TITLE
⚡ Bolt: Parallelize job scraping and resume query

### DIFF
--- a/backend/routers/job_match.py
+++ b/backend/routers/job_match.py
@@ -158,9 +158,13 @@ async def scrape_jobs_for_fields(
     if not fields:
         raise HTTPException(status_code=400, detail="At least one field is required.")
 
-    # 1. Scrape jobs
     limit = max(1, min(payload.limit, 50))
-    jobs = await scrape_jobs(
+
+    # ⚡ Bolt: Parallelize job scraping and database query
+    # What: Uses asyncio.gather and asyncio.to_thread to run job scraping and the Supabase resume query concurrently.
+    # Why: Job scraping involves external network calls, and Supabase client .execute() is synchronous; doing them in series adds unnecessary latency.
+    # Impact: Hides the database query latency (~50-100ms) behind the longer scraping network request, speeding up the overall request.
+    scrape_task = scrape_jobs(
         fields,
         payload.location,
         payload.remote_only,
@@ -168,16 +172,17 @@ async def scrape_jobs_for_fields(
         payload.workplace_type or "any",
         payload.job_type or "any"
     )
-    
-    # 2. Fetch user's latest resume for auto-matching
-    r = (
-        db.table("resumes")
+
+    resume_task = asyncio.to_thread(
+        lambda: db.table("resumes")
         .select("raw_text")
         .eq("user_id", user["user_id"])
         .order("created_at", desc=True)
         .limit(1)
         .execute()
     )
+
+    jobs, r = await asyncio.gather(scrape_task, resume_task)
     
     if r.data:
         resume_text = r.data[0]["raw_text"]


### PR DESCRIPTION
💡 What: Converted sequential execution of job scraping and database resume fetching in `scrape_jobs_for_fields` to run concurrently using `asyncio.gather` and `asyncio.to_thread`.
🎯 Why: The Supabase python client is synchronous, and `scrape_jobs` makes external HTTP requests. Running them in series blocked the event loop unnecessarily and added sequential delays.
📊 Impact: Reduces total latency for the `/scrape-jobs` endpoint by hiding the DB query time (~50-100ms) behind the longer external scraping requests.
🔬 Measurement: Can be verified by measuring response times of the `/scrape-jobs` API endpoint under load.

---
*PR created automatically by Jules for task [15122571264054712410](https://jules.google.com/task/15122571264054712410) started by @SudoAnirudh*