### PR TITLE
⚡ Bolt: [performance improvement] Concurrent Supabase queries in Outreach service

### DIFF
--- a/backend/services/outreach_service.py
+++ b/backend/services/outreach_service.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import asyncio
 from typing import Optional, Any
 from services.nvidia_client import invoke_nvidia_llm
 from models.analysis import OutreachDraftsResponse
@@ -16,8 +17,14 @@ async def generate_outreach_drafts(
     Generates personalized LinkedIn and Email outreach drafts using Hirenix AI.
     """
     try:
+        # What: Run Supabase .execute() queries concurrently using asyncio.to_thread and asyncio.gather.
+        # Why: Supabase python client is synchronous. Calling .execute() blocks the async event loop.
+        match_task = asyncio.to_thread(lambda: db.table("job_matches").select("*").eq("id", match_id).eq("user_id", user_id).single().execute())
+        li_task = asyncio.to_thread(lambda: db.table("linkedin_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
+
+        match_query, li_query = await asyncio.gather(match_task, li_task)
+
         # 1. Fetch Job Match Data
-        match_query = db.table("job_matches").select("*").eq("id", match_id).eq("user_id", user_id).single().execute()
         if not match_query.data:
             logger.error(f"Job match {match_id} not found for user {user_id}")
             return None
@@ -30,8 +37,6 @@ async def generate_outreach_drafts(
         bridge_advice = match_data.get("metadata", {}).get("bridge_advice", [])
 
         # 2. Fetch LinkedIn Profile Summary (for personalization)
-        li_query = db.table("linkedin_analyses").select("*").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
-        
         profile_context = ""
         if li_query.data:
             li_data = li_query.data[0]
@@ -43,7 +48,7 @@ async def generate_outreach_drafts(
             profile_context = f"User Profile Summary: {profile_summary}\nKey Strengths: {', '.join(strengths)}"
         else:
             # Fallback to resume if LinkedIn not available
-            resume_query = db.table("resumes").select("raw_text").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute()
+            resume_query = await asyncio.to_thread(lambda: db.table("resumes").select("raw_text").eq("user_id", user_id).order("created_at", desc=True).limit(1).execute())
             if resume_query.data:
                 profile_context = f"Candidate Background: {resume_query.data[0].get('raw_text', '')[:1000]}"
 


### PR DESCRIPTION
💡 What: Replaced sequential synchronous Supabase `.execute()` queries in `generate_outreach_drafts` with concurrent execution using `asyncio.to_thread` and `asyncio.gather`.
🎯 Why: The Supabase Python client's `.execute()` method is blocking. Running multiple queries sequentially inside the `async` FastAPI endpoint blocked the main event loop, leading to increased latency.
📊 Impact: Reduces the I/O bottleneck by fetching job match data and LinkedIn profile data simultaneously, lowering the overall endpoint latency.
🔬 Measurement: Endpoint latency metrics for `/outreach-drafts` will reflect a decrease proportional to the slowest concurrent query, instead of the sum of both queries.

---
*PR created automatically by Jules for task [2790006615911054240](https://jules.google.com/task/2790006615911054240) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved response speed by fetching multiple data sources concurrently instead of one after another.
  * Reduced blocking during outreach generation, helping the app stay more responsive.
* **Bug Fixes**
  * Kept fallback data retrieval non-blocking when LinkedIn information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->