### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information disclosure via exception leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** User input was being directly interpolated into Supabase PostgREST `.or_()` clauses.
 **Learning:** Commas and parentheses in strings are interpreted as syntactic boundaries in PostgREST filters, leading to injection vulnerabilities.
 **Prevention:** Added a `sanitize_postgrest_filter` utility function to strip out commas, parentheses, and double-quotes from user input before usage in these clauses.
+## 2025-01-09 - Information Disclosure via Exception Leakage
+**Vulnerability:** Raw exception messages (`str(e)`) were being exposed to the client in HTTP 500 responses and unhandled OS file exceptions were not caught, risking information disclosure.
+**Learning:** Returning `str(e)` directly in an `HTTPException` can leak sensitive internal details, paths, or logic if an unhandled error occurs.
+**Prevention:** Always log the detailed error internally using a logger and return a sanitized, generic error message in the API response. Catch broad `Exception` in OS-level file operations and log them securely.

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -390,7 +390,7 @@ async def transcribe(
         return {"text": text}
     except Exception as e:
         logger.error(f"Transcription route failure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Transcription failed due to an internal error.")
 
 
 @router.post("/next-question", response_model=InterviewQuestion)

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -78,4 +78,5 @@ async def trigger_jobs_sync(
         new_jobs = await sync_twitter_jobs()
         return {"status": "success", "message": f"Sync complete. Added {new_jobs} jobs."}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Jobs sync failure: {e}")
+        raise HTTPException(status_code=500, detail="An error occurred while syncing jobs.")

--- a/backend/utils/file_handler.py
+++ b/backend/utils/file_handler.py
@@ -2,9 +2,11 @@ import aiofiles
 import os
 import tempfile
 from fastapi import UploadFile
-
+import logging
 
 import uuid
+
+logger = logging.getLogger(__name__)
 
 async def save_upload_temp(file: UploadFile) -> str:
     """Save an uploaded file to /tmp and return the temp path."""
@@ -26,5 +28,5 @@ def cleanup_temp(path: str) -> None:
         if not real_path.startswith(os.path.realpath(temp_dir)):
             return
         os.remove(real_path)
-    except FileNotFoundError:
-        pass
+    except Exception as e:
+        logger.error(f"Failed to cleanup temp file {path}: {e}")

--- a/frontend/app/dashboard/roadmap/page.tsx
+++ b/frontend/app/dashboard/roadmap/page.tsx
@@ -130,7 +130,7 @@ export default function RoadmapPage() {
 
     // Flatten all completed skills for the backend
     const getCompletedNames = (skills: RoadmapSkill[]): string[] => {
-      let names: string[] = [];
+      const names: string[] = [];
       skills.forEach((s) => {
         if (s.status === "completed") names.push(s.name);
         if (s.children) names.push(...getCompletedNames(s.children));


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Raw exception messages (`str(e)`) were being exposed to the client in HTTP 500 responses (`interview.py`, `jobs_board.py`), and unhandled OS file exceptions were not caught in `file_handler.py`, risking information disclosure via exception leakage.
🎯 **Impact**: If an unhandled error occurred, the application could leak sensitive internal details, paths, or logic directly to the user/attacker. Uncaught exceptions in temp file cleanup could also propagate to 500 errors.
🔧 **Fix**: 
- Replaced `detail=str(e)` with generic error messages in `raise HTTPException(status_code=500)` calls.
- Ensured all detailed errors are logged internally using `logger.error()`.
- Added broad `Exception` catching to `cleanup_temp` in `file_handler.py` to 'fail securely'.
✅ **Verification**: Run `PYTHONPATH=. pytest backend/tests/` to verify tests still pass and review the diff to ensure raw exception strings are no longer passed to `detail`.

---
*PR created automatically by Jules for task [11233573443353769245](https://jules.google.com/task/11233573443353769245) started by @SudoAnirudh*