### PR TITLE
🎨 Palette: Add ARIA label and focus states to application menu button

### DIFF
--- a/frontend/app/dashboard/applications/page.tsx
+++ b/frontend/app/dashboard/applications/page.tsx
@@ -221,7 +221,9 @@ function JobCard({
         <div className="relative">
           <button
             onClick={() => setShowMenu(!showMenu)}
-            className="p-1 px-1.5 rounded-lg text-slate-400 group- transition-colors"
+            aria-label="Application options"
+            aria-expanded={showMenu}
+            className="p-1 px-1.5 rounded-lg text-slate-400 hover:text-slate-600 hover:bg-slate-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
           >
             <MoreVertical size={14} />
           </button>


### PR DESCRIPTION
### 💡 What
Added `aria-label`, `aria-expanded`, and keyboard focus styles (`focus-visible`) to the icon-only options menu button on the Application Card.
Also fixed a dangling class string `group-`.

### 🎯 Why
The button was completely inaccessible to screen reader users (lacked context) and keyboard users (no focus state), making it impossible for them to manage their tracked job applications.

### 📸 Before/After
No visual difference unless navigating by keyboard (now shows an indigo focus ring).

### ♿ Accessibility
- Added `aria-label="Application options"` for screen readers.
- Added `aria-expanded={showMenu}` to communicate toggle state.
- Added `focus-visible:ring-2` to support keyboard navigation.

---
*PR created automatically by Jules for task [16684851886904714067](https://jules.google.com/task/16684851886904714067) started by @SudoAnirudh*