### PR TITLE
🎨 Palette: [UX improvement]

### DIFF
--- a/frontend/app/dashboard/roadmap/page.tsx
+++ b/frontend/app/dashboard/roadmap/page.tsx
@@ -130,7 +130,7 @@ export default function RoadmapPage() {
 
     // Flatten all completed skills for the backend
     const getCompletedNames = (skills: RoadmapSkill[]): string[] => {
-      let names: string[] = [];
+      const names: string[] = [];
       skills.forEach((s) => {
         if (s.status === "completed") names.push(s.name);
         if (s.children) names.push(...getCompletedNames(s.children));

--- a/frontend/components/InterviewPanel.tsx
+++ b/frontend/components/InterviewPanel.tsx
@@ -803,12 +803,13 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
             type="button"
             onClick={toggleListening}
             disabled={!speechSupported || submitting || transcribing}
-            className={`p-3.5 rounded-full transition-all active:scale-90 ${
+            className={`p-3.5 rounded-full transition-all active:scale-90 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-indigo-500 ${
               isListening
                 ? "bg-red-500 hover:bg-red-600 text-white shadow-lg shadow-red-500/20"
                 : "bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
             } disabled:opacity-50`}
             title={isListening ? "Mute Microphone" : "Unmute Microphone"}
+            aria-label={isListening ? "Mute Microphone" : "Unmute Microphone"}
           >
             {isListening ? <Mic size={18} /> : <MicOff size={18} />}
           </button>
@@ -818,12 +819,13 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
             type="button"
             onClick={() => setCameraOn(!cameraOn)}
             disabled={submitting || transcribing}
-            className={`p-3.5 rounded-full transition-all active:scale-90 ${
+            className={`p-3.5 rounded-full transition-all active:scale-90 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-indigo-500 ${
               cameraOn
                 ? "bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
                 : "bg-red-500 hover:bg-red-600 text-white shadow-lg shadow-red-500/20"
             }`}
             title={cameraOn ? "Stop Video" : "Start Video"}
+            aria-label={cameraOn ? "Stop Video" : "Start Video"}
           >
             {cameraOn ? <Video size={18} /> : <VideoOff size={18} />}
           </button>
@@ -854,8 +856,9 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
             <button
               type="button"
               onClick={onExit}
-              className="p-3.5 rounded-full bg-slate-800 hover:bg-slate-700 text-red-400 border border-slate-700 transition-all active:scale-90"
+              className="p-3.5 rounded-full bg-slate-800 hover:bg-slate-700 text-red-400 border border-slate-700 transition-all active:scale-90 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-indigo-500"
               title="Hang Up / Exit Interview"
+              aria-label="Hang Up / Exit Interview"
             >
               <PhoneOff size={18} />
             </button>


### PR DESCRIPTION
💡 What: Added aria-labels and keyboard focus indicators to icon-only control buttons (Mic, Camera, Exit) in the Interview Panel.
🎯 Why: Improves screen reader accessibility and keyboard navigation visibility for users interacting without a mouse.
📸 Before/After: Before, buttons lacked explicit aria-labels and focus rings. After, they are fully keyboard-navigable with clear focus states and screen reader descriptions.
♿ Accessibility: Ensured icon-only buttons meet WCAG guidelines by providing text alternatives via aria-label and visible focus rings.

---
*PR created automatically by Jules for task [11901699577085887569](https://jules.google.com/task/11901699577085887569) started by @SudoAnirudh*