### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Exception Information Disclosure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** User input was being directly interpolated into Supabase PostgREST `.or_()` clauses.
 **Learning:** Commas and parentheses in strings are interpreted as syntactic boundaries in PostgREST filters, leading to injection vulnerabilities.
 **Prevention:** Added a `sanitize_postgrest_filter` utility function to strip out commas, parentheses, and double-quotes from user input before usage in these clauses.
+## 2024-05-28 - [Information Disclosure via Exception Detail Leakage]
+**Vulnerability:** Raw exception strings (e.g., `detail=str(e)`) were being passed directly to `HTTPException` responses in `jobs_board.py` and `interview.py`.
+**Learning:** Returning unhandled exception details directly to the client can inadvertently leak sensitive internal system information, stack traces, or configuration paths, which violates the "fail securely" principle.
+**Prevention:** Always log the detailed error internally using a logger (e.g., `logger.error`) and return a sanitized, generic error message (e.g., "An internal error occurred") to the user in the `HTTPException`.

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -390,7 +390,7 @@ async def transcribe(
         return {"text": text}
     except Exception as e:
         logger.error(f"Transcription route failure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="An internal error occurred during transcription.")
 
 
 @router.post("/next-question", response_model=InterviewQuestion)

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -78,4 +78,5 @@ async def trigger_jobs_sync(
         new_jobs = await sync_twitter_jobs()
         return {"status": "success", "message": f"Sync complete. Added {new_jobs} jobs."}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Jobs sync failed: {e}")
+        raise HTTPException(status_code=500, detail="An internal error occurred during jobs sync.")


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Raw exception strings (`detail=str(e)`) were being returned directly to users in 500 error responses from the jobs sync and transcription endpoints.
🎯 Impact: Could leak sensitive internal system details, stack traces, or configuration paths to an attacker.
🔧 Fix: Replaced `str(e)` with sanitized, generic error messages (e.g., "An internal error occurred") in the HTTP response, while ensuring the actual exception details are still logged internally for debugging.
✅ Verification: Run the test suite (`pnpm test` / `pytest`) and check the `jobs_board` and `interview` router responses to ensure generic error messages are returned on failure.

---
*PR created automatically by Jules for task [5820313955836815533](https://jules.google.com/task/5820313955836815533) started by @SudoAnirudh*