### PR TITLE
🎨 Palette: [UX improvement] Add aria-expanded to mobile menu button

### DIFF
--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -268,7 +268,9 @@ export default function DashboardLayout({
           {/* Menu Button */}
           <button
             onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-            className={`relative flex-1 flex flex-col items-center justify-center py-2.5 px-1 rounded-2xl transition-all duration-300 ${
+            aria-expanded={isMobileMenuOpen}
+            aria-label="Toggle mobile menu"
+            className={`relative flex-1 flex flex-col items-center justify-center py-2.5 px-1 rounded-2xl transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 ${
               isMobileMenuOpen
                 ? "text-indigo-500 bg-indigo-500/10"
                 : "text-muted-foreground"


### PR DESCRIPTION
💡 What: Added `aria-expanded` and `aria-label` attributes to the mobile navigation toggle button in the dashboard layout, along with `focus-visible` styling.
🎯 Why: Without an `aria-expanded` attribute, screen reader users cannot determine if the mobile menu is open or closed, and without `focus-visible` rings, keyboard users struggle to perceive when the menu button is focused.
📸 Before/After: N/A
♿ Accessibility: The button is now fully navigable via keyboard, and exposes its current toggled state via ARIA to assistive technologies.

---
*PR created automatically by Jules for task [7490622791559170296](https://jules.google.com/task/7490622791559170296) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the mobile menu button’s accessibility by announcing its expanded state and adding a clear label for assistive technologies.
  * Enhanced keyboard navigation with visible focus styling, making the button easier to use without a mouse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->