### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Exception Detail Leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** User input was being directly interpolated into Supabase PostgREST `.or_()` clauses.
 **Learning:** Commas and parentheses in strings are interpreted as syntactic boundaries in PostgREST filters, leading to injection vulnerabilities.
 **Prevention:** Added a `sanitize_postgrest_filter` utility function to strip out commas, parentheses, and double-quotes from user input before usage in these clauses.
+## 2024-05-28 - Information Disclosure via Exception Detail Leakage
+**Vulnerability:** Raw exception strings (`str(e)`) were being returned directly to clients in 500 `HTTPException` responses in `backend/routers/jobs_board.py` and `backend/routers/interview.py`.
+**Learning:** Returning raw exception details can inadvertently expose internal system workings, stack traces, or sensitive configurations to attackers, aiding them in profiling the system.
+**Prevention:** Always log the detailed exception internally for debugging, but return generic, sanitized error messages to the client (e.g., "An internal error occurred").

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -390,7 +390,7 @@ async def transcribe(
         return {"text": text}
     except Exception as e:
         logger.error(f"Transcription route failure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Transcription failed.")
 
 
 @router.post("/next-question", response_model=InterviewQuestion)

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -78,4 +78,5 @@ async def trigger_jobs_sync(
         new_jobs = await sync_twitter_jobs()
         return {"status": "success", "message": f"Sync complete. Added {new_jobs} jobs."}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Error during job sync: {e}")
+        raise HTTPException(status_code=500, detail="An internal error occurred during sync.")


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Raw exception strings (`str(e)`) were being returned to the client in 500 error responses in `jobs_board.py` and `interview.py`, which could lead to information disclosure.
🎯 Impact: Attackers could gain insights into the internal architecture, stack traces, or configurations, aiding in further attacks.
🔧 Fix: Replaced raw exception details with generic error messages in API responses, ensuring detailed errors are only logged internally.
✅ Verification: Run `PYTHONPATH=backend pytest backend/tests/` to verify tests pass and check the endpoints to ensure they return generic 500 errors.

---
*PR created automatically by Jules for task [17304956954410490512](https://jules.google.com/task/17304956954410490512) started by @SudoAnirudh*