### PR TITLE
🎨 Palette: Add explicit label-to-input associations in Add Application modal

### DIFF
--- a/frontend/components/dashboard/AddApplicationModal.tsx
+++ b/frontend/components/dashboard/AddApplicationModal.tsx
@@ -107,7 +107,7 @@ export default function AddApplicationModal({
                 <form onSubmit={handleSubmit} className="space-y-6">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div className="space-y-2">
-                      <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                      <label htmlFor="company" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                         Company
                       </label>
                       <div className="relative">
@@ -116,6 +116,7 @@ export default function AddApplicationModal({
                           className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                         />
                         <input
+                          id="company"
                           type="text"
                           required
                           className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
@@ -132,7 +133,7 @@ export default function AddApplicationModal({
                     </div>
 
                     <div className="space-y-2">
-                      <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                      <label htmlFor="role" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                         Role
                       </label>
                       <div className="relative">
@@ -141,6 +142,7 @@ export default function AddApplicationModal({
                           className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                         />
                         <input
+                          id="role"
                           type="text"
                           required
                           className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
@@ -155,7 +157,7 @@ export default function AddApplicationModal({
                   </div>
 
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                    <label htmlFor="location" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                       Location
                     </label>
                     <div className="relative">
@@ -164,6 +166,7 @@ export default function AddApplicationModal({
                         className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                       />
                       <input
+                        id="location"
                         type="text"
                         className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
                         placeholder="e.g. Remote, TX"
@@ -176,7 +179,7 @@ export default function AddApplicationModal({
                   </div>
 
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                    <label htmlFor="apply_url" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                       Job Link
                     </label>
                     <div className="relative">
@@ -185,6 +188,7 @@ export default function AddApplicationModal({
                         className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                       />
                       <input
+                        id="apply_url"
                         type="url"
                         className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
                         placeholder="https://..."


### PR DESCRIPTION
💡 What: Added `htmlFor` to `<label>` elements and matching `id` attributes to corresponding `<input>` elements for the Company, Role, Location, and Job Link fields in `AddApplicationModal.tsx`.
🎯 Why: React form labels frequently omitted these explicit associations in this repository, which hinders screen reader context and prevents standard click-to-focus accessibility.
📸 Before/After: Before, clicking a label did nothing, and screen readers lacked explicit programmatic association. After, clicking the label correctly focuses the corresponding input, and screen readers will reliably read the label text.
♿ Accessibility: Improves accessibility significantly for both screen-reader and mouse users by explicitly associating form labels with their respective inputs.

---
*PR created automatically by Jules for task [17801619652332466470](https://jules.google.com/task/17801619652332466470) started by @SudoAnirudh*