### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent info disclosure in file cleanup

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** User input was being directly interpolated into Supabase PostgREST `.or_()` clauses.
 **Learning:** Commas and parentheses in strings are interpreted as syntactic boundaries in PostgREST filters, leading to injection vulnerabilities.
 **Prevention:** Added a `sanitize_postgrest_filter` utility function to strip out commas, parentheses, and double-quotes from user input before usage in these clauses.
+## 2025-01-08 - [Fail Securely in OS File Operations]
+**Vulnerability:** OS-level file operations (like `os.remove`) during cleanup were only catching `FileNotFoundError`. Other exceptions could propagate and leak internal paths or stack traces in 500 responses.
+**Learning:** System operations can fail for many reasons (e.g., permissions, locks). Unhandled exceptions in cleanup routines break the "fail securely" principle and risk information disclosure.
+**Prevention:** Always catch broad exceptions like `Exception` in cleanup/teardown routines, log them securely, and prevent them from propagating to the client.

--- a/backend/utils/file_handler.py
+++ b/backend/utils/file_handler.py
@@ -5,6 +5,9 @@ from fastapi import UploadFile
 
 
 import uuid
+import logging
+
+logger = logging.getLogger("hirenix.file_handler")
 
 async def save_upload_temp(file: UploadFile) -> str:
     """Save an uploaded file to /tmp and return the temp path."""
@@ -26,5 +29,5 @@ def cleanup_temp(path: str) -> None:
         if not real_path.startswith(os.path.realpath(temp_dir)):
             return
         os.remove(real_path)
-    except FileNotFoundError:
-        pass
+    except Exception as e:
+        logger.error(f"Failed to securely remove temporary file: {e}")


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unhandled exceptions in OS-level file operations during temporary file cleanup (like `os.remove` throwing a `PermissionError`) broke the "fail securely" principle and risked propagating to a 500 error response, potentially leaking internal paths or stack traces.
🎯 **Impact:** Risk of information disclosure via error responses.
🔧 **Fix:** Added logging and changed the catch block in `cleanup_temp` to catch broad `Exception` instead of just `FileNotFoundError`.
✅ **Verification:** Verified code logic in `backend/utils/file_handler.py` and successfully ran the backend test suite.

---
*PR created automatically by Jules for task [17141599455530060078](https://jules.google.com/task/17141599455530060078) started by @SudoAnirudh*