### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Exception Detail Leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** OS-level file operations (like `os.remove`) during cleanup were only catching `FileNotFoundError`. Other exceptions could propagate and leak internal paths or stack traces in 500 responses.
 **Learning:** System operations can fail for many reasons (e.g., permissions, locks). Unhandled exceptions in cleanup routines break the "fail securely" principle and risk information disclosure.
 **Prevention:** Always catch broad exceptions like `Exception` in cleanup/teardown routines, log them securely, and prevent them from propagating to the client.
+## 2025-01-08 - [Exception Detail Leakage]
+**Vulnerability:** Raw exception strings (`detail=str(e)`) were being returned directly to the client in HTTP 500 error responses in `jobs_board.py` and `interview.py`.
+**Learning:** Exposing internal exception details (like stack traces or system paths) violates the "fail securely" principle and creates an information disclosure vulnerability that attackers can use to map backend infrastructure.
+**Prevention:** Always log detailed exception messages internally and return sanitized, generic error messages to the client.

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -390,7 +390,7 @@ async def transcribe(
         return {"text": text}
     except Exception as e:
         logger.error(f"Transcription route failure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Transcription service failed.")
 
 
 @router.post("/next-question", response_model=InterviewQuestion)

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -78,4 +78,5 @@ async def trigger_jobs_sync(
         new_jobs = await sync_twitter_jobs()
         return {"status": "success", "message": f"Sync complete. Added {new_jobs} jobs."}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Jobs sync failed: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error during jobs sync.")


### PR DESCRIPTION
**🛡️ Sentinel: [MEDIUM] Fix Exception Detail Leakage**

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Raw exception strings (`detail=str(e)`) were being returned directly to the client in HTTP 500 error responses in `backend/routers/jobs_board.py` and `backend/routers/interview.py`.
🎯 **Impact:** Exposing internal exception details (like stack traces, system paths, or downstream API error messages) violates the "fail securely" principle and creates an information disclosure vulnerability that attackers can use to map backend infrastructure or understand internal system state.
🔧 **Fix:** Replaced `detail=str(e)` with generic error messages ("Internal server error during jobs sync." and "Transcription service failed.") and ensured the detailed exceptions are logged internally using `logger.error()`.
✅ **Verification:** Verified that the changes were applied correctly using `sed` and ran backend tests (`python -m pytest backend/tests/`) to ensure no regressions were introduced. Added a security learning to `.jules/sentinel.md` to prevent future occurrences.

---
*PR created automatically by Jules for task [17183489693661569032](https://jules.google.com/task/17183489693661569032) started by @SudoAnirudh*