### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in Error Handling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** OS-level file operations (like `os.remove`) during cleanup were only catching `FileNotFoundError`. Other exceptions could propagate and leak internal paths or stack traces in 500 responses.
 **Learning:** System operations can fail for many reasons (e.g., permissions, locks). Unhandled exceptions in cleanup routines break the "fail securely" principle and risk information disclosure.
 **Prevention:** Always catch broad exceptions like `Exception` in cleanup/teardown routines, log them securely, and prevent them from propagating to the client.
+## 2025-02-18 - [Information Disclosure in Exception Handling]
+**Vulnerability:** Raw exception strings (e.g., `detail=str(e)`) were being passed directly to `HTTPException` responses in `backend/routers/jobs_board.py` and `backend/routers/interview.py`.
+**Learning:** Exposing raw exception messages can leak sensitive internal information, stack traces, database schema details, or system paths to external clients. This violates the principle of failing securely.
+**Prevention:** Always log the detailed exception internally using a logger (e.g., `logger.error(f"Error: {e}")`) and return a sanitized, generic error message (e.g., `"Internal server error"`) to the client.

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -390,7 +390,7 @@ async def transcribe(
         return {"text": text}
     except Exception as e:
         logger.error(f"Transcription route failure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Transcription service failed.")
 
 
 @router.post("/next-question", response_model=InterviewQuestion)

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -78,4 +78,5 @@ async def trigger_jobs_sync(
         new_jobs = await sync_twitter_jobs()
         return {"status": "success", "message": f"Sync complete. Added {new_jobs} jobs."}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Error during jobs sync: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error during jobs sync.")


### PR DESCRIPTION
🚨 **Severity**: MEDIUM

💡 **Vulnerability**: The application was leaking raw internal exception strings (`str(e)`) directly to clients inside `HTTPException(status_code=500)` responses in `backend/routers/jobs_board.py` and `backend/routers/interview.py`.

🎯 **Impact**: An attacker or external user could potentially view internal system paths, database connection strings, API failures, or stack trace fragments, which aids in reconnaissance and breaks the "fail securely" principle.

🔧 **Fix**: 
- Replaced the direct exposure of `str(e)` with safe, generic fallback messages (`"Internal server error during jobs sync."` and `"Transcription service failed."`).
- Ensured the actual detailed exception is securely logged internally using the `logger` object for debugging purposes.

✅ **Verification**: 
- Ran `pytest` suite ensuring all tests pass.
- Used grep to verify no `detail=str(e)` leakage remains in the patched router files.

---
*PR created automatically by Jules for task [10311755608120384379](https://jules.google.com/task/10311755608120384379) started by @SudoAnirudh*