### PR TITLE
⚡ Bolt: Optimize export_cover_letter endpoint

### DIFF
--- a/backend/routers/cover_letter.py
+++ b/backend/routers/cover_letter.py
@@ -1,5 +1,6 @@
 import uuid
 import datetime
+import asyncio
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from dependencies import get_current_user, get_supabase_admin
@@ -93,25 +94,14 @@ async def export_cover_letter(
     db=Depends(get_supabase_admin),
 ):
     """Exports a cover letter as PDF or Docx."""
-    r = (
-        db.table("cover_letters")
-        .select("*")
-        .eq("id", letter_id)
-        .eq("user_id", user["user_id"])
-        .single()
-        .execute()
-    )
+    # Run the two independent Supabase queries concurrently
+    cover_letter_task = asyncio.to_thread(lambda: db.table("cover_letters").select("*").eq("id", letter_id).eq("user_id", user["user_id"]).single().execute())
+    profile_task = asyncio.to_thread(lambda: db.table("profiles").select("full_name").eq("id", user["user_id"]).single().execute())
+
+    r, p = await asyncio.gather(cover_letter_task, profile_task)
+
     if not r.data:
         raise HTTPException(status_code=404, detail="Cover letter not found.")
-
-    # Fetch user profile for headers
-    p = (
-        db.table("profiles")
-        .select("full_name")
-        .eq("id", user["user_id"])
-        .single()
-        .execute()
-    )
     
     header_info = {
         "name": p.data.get("full_name", "Valued User"),


### PR DESCRIPTION
💡 What: Wrapped two sequential synchronous Supabase database queries in `asyncio.to_thread` and executed them concurrently using `asyncio.gather` within the `export_cover_letter` endpoint in `backend/routers/cover_letter.py`.

🎯 Why: The Supabase Python client's `.execute()` method is synchronous. Running multiple queries in series blocks the FastAPI asynchronous event loop, increasing endpoint latency and limiting scalability.

📊 Impact: Halves the database I/O wait time for this endpoint by resolving the queries in parallel, preventing event loop blocking.

🔬 Measurement: Compare the response time of the `/export/{letter_id}` endpoint before and after the change; it should reflect the maximum latency of the longest query rather than the sum of both.

---
*PR created automatically by Jules for task [17571354125375208772](https://jules.google.com/task/17571354125375208772) started by @SudoAnirudh*