### PR TITLE
🎨 Palette: Add aria-label to icon buttons in Interview Panel

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,1 @@
+## 2024-07-18 - Missing ARIA Labels on Icon Buttons\n**Learning:** The `InterviewPanel` component uses icon-only buttons for critical actions (microphone and camera toggles) but relies solely on `title` attributes. Screen readers prefer explicit `aria-label`s for better accessibility.\n**Action:** Add `aria-label` to icon-only buttons like those in `InterviewPanel.tsx`.

--- a/frontend/components/InterviewPanel.tsx
+++ b/frontend/components/InterviewPanel.tsx
@@ -809,6 +809,7 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
                 : "bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
             } disabled:opacity-50`}
             title={isListening ? "Mute Microphone" : "Unmute Microphone"}
+            aria-label={isListening ? "Mute Microphone" : "Unmute Microphone"}
           >
             {isListening ? <Mic size={18} /> : <MicOff size={18} />}
           </button>
@@ -824,6 +825,7 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
                 : "bg-red-500 hover:bg-red-600 text-white shadow-lg shadow-red-500/20"
             }`}
             title={cameraOn ? "Stop Video" : "Start Video"}
+            aria-label={cameraOn ? "Stop Video" : "Start Video"}
           >
             {cameraOn ? <Video size={18} /> : <VideoOff size={18} />}
           </button>
@@ -856,6 +858,7 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
               onClick={onExit}
               className="p-3.5 rounded-full bg-slate-800 hover:bg-slate-700 text-red-400 border border-slate-700 transition-all active:scale-90"
               title="Hang Up / Exit Interview"
+              aria-label="Hang Up / Exit Interview"
             >
               <PhoneOff size={18} />
             </button>

--- a/test_plan.txt
+++ b/test_plan.txt
@@ -1,0 +1,1 @@
+I will fix the accessibility issues in `frontend/components/InterviewPanel.tsx`. Specifically, I will add `aria-label` attributes to the icon-only buttons for toggling microphone, toggling camera, and hanging up.


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the icon-only buttons (microphone toggle, camera toggle, hang up) in the InterviewPanel component.
🎯 Why: Icon-only buttons rely on visual cues or `title` tooltips, which aren't always reliably read by screen readers. Adding explicit `aria-label`s makes these crucial interview controls fully accessible to users relying on assistive technologies.
📸 Before/After: Before, buttons only had `title` attributes. After, they also have matching `aria-label`s.
♿ Accessibility: Improves screen reader compatibility for interactive elements without text content, fulfilling standard a11y requirements.

---
*PR created automatically by Jules for task [2454500194606124952](https://jules.google.com/task/2454500194606124952) started by @SudoAnirudh*