### PR TITLE
🎨 Palette: Add htmlFor to form labels for accessibility

### DIFF
--- a/frontend/components/dashboard/AddApplicationModal.tsx
+++ b/frontend/components/dashboard/AddApplicationModal.tsx
@@ -107,7 +107,7 @@ export default function AddApplicationModal({
                 <form onSubmit={handleSubmit} className="space-y-6">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div className="space-y-2">
-                      <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                      <label htmlFor="company" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                         Company
                       </label>
                       <div className="relative">
@@ -116,6 +116,7 @@ export default function AddApplicationModal({
                           className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                         />
                         <input
+                          id="company"
                           type="text"
                           required
                           className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
@@ -132,7 +133,7 @@ export default function AddApplicationModal({
                     </div>
 
                     <div className="space-y-2">
-                      <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                      <label htmlFor="role" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                         Role
                       </label>
                       <div className="relative">
@@ -141,6 +142,7 @@ export default function AddApplicationModal({
                           className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                         />
                         <input
+                          id="role"
                           type="text"
                           required
                           className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
@@ -155,7 +157,7 @@ export default function AddApplicationModal({
                   </div>
 
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                    <label htmlFor="location" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                       Location
                     </label>
                     <div className="relative">
@@ -164,6 +166,7 @@ export default function AddApplicationModal({
                         className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                       />
                       <input
+                        id="location"
                         type="text"
                         className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
                         placeholder="e.g. Remote, TX"
@@ -176,7 +179,7 @@ export default function AddApplicationModal({
                   </div>
 
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                    <label htmlFor="job-link" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                       Job Link
                     </label>
                     <div className="relative">
@@ -185,6 +188,7 @@ export default function AddApplicationModal({
                         className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                       />
                       <input
+                        id="job-link"
                         type="url"
                         className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
                         placeholder="https://..."

--- a/frontend/components/dashboard/OnboardingWizard.tsx
+++ b/frontend/components/dashboard/OnboardingWizard.tsx
@@ -198,10 +198,11 @@ export default function OnboardingWizard({
 
             <div className="space-y-6 bg-white/5 border border-white/10 p-8 rounded-[32px] backdrop-blur-xl">
               <div>
-                <label className="block text-sm font-bold text-slate-300 mb-2 uppercase tracking-wide">
+                <label htmlFor="target-role" className="block text-sm font-bold text-slate-300 mb-2 uppercase tracking-wide">
                   Target Role
                 </label>
                 <input
+                  id="target-role"
                   value={role}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                     setRole(e.target.value)
@@ -211,10 +212,11 @@ export default function OnboardingWizard({
                 />
               </div>
               <div>
-                <label className="block text-sm font-bold text-slate-300 mb-2 uppercase tracking-wide">
+                <label htmlFor="dream-company" className="block text-sm font-bold text-slate-300 mb-2 uppercase tracking-wide">
                   Dream Company (Optional)
                 </label>
                 <input
+                  id="dream-company"
                   value={company}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                     setCompany(e.target.value)


### PR DESCRIPTION
## 💡 What
Added `htmlFor` attributes to `<label>` elements and matching `id` attributes to corresponding `<input>` elements in `AddApplicationModal` and `OnboardingWizard` components.

## 🎯 Why
React form labels in this repository frequently omit `htmlFor` attribute pairing them with input `id`s. This breaks accessibility where clicking a label focuses its input, which is particularly relevant for form inputs.

## 📸 Before/After
Before: Labels could not be clicked to focus inputs. Screen readers could not easily associate labels with inputs.
After: Clicking on labels such as "Company", "Role", "Location", "Job Link" in the modal, or "Target Role" and "Dream Company" in the wizard now correctly focuses the corresponding input fields. Screen readers can correctly interpret the association.

## ♿ Accessibility
Improved form accessibility by adding programmatic association between labels and input fields. This enhances support for screen readers and allows click-to-focus behavior, benefiting users navigating via keyboard and assistive technologies.

---
*PR created automatically by Jules for task [10991552640955516759](https://jules.google.com/task/10991552640955516759) started by @SudoAnirudh*