### PR TITLE
🎨 Palette: Improve form label accessibility

### DIFF
--- a/frontend/components/dashboard/AddApplicationModal.tsx
+++ b/frontend/components/dashboard/AddApplicationModal.tsx
@@ -85,7 +85,7 @@ export default function AddApplicationModal({
                 <button
                   onClick={onClose}
                   aria-label="Close modal"
-                  className="absolute top-6 right-6 p-2 rounded-full dark: text-slate-400 transition-colors"
+                  className="absolute top-6 right-6 p-2 rounded-full text-slate-400 transition-colors"
                 >
                   <X size={20} />
                 </button>
@@ -107,7 +107,7 @@ export default function AddApplicationModal({
                 <form onSubmit={handleSubmit} className="space-y-6">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div className="space-y-2">
-                      <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                      <label htmlFor="company" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                         Company
                       </label>
                       <div className="relative">
@@ -116,6 +116,7 @@ export default function AddApplicationModal({
                           className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                         />
                         <input
+                          id="company"
                           type="text"
                           required
                           className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
@@ -132,7 +133,7 @@ export default function AddApplicationModal({
                     </div>
 
                     <div className="space-y-2">
-                      <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                      <label htmlFor="role" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                         Role
                       </label>
                       <div className="relative">
@@ -141,6 +142,7 @@ export default function AddApplicationModal({
                           className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                         />
                         <input
+                          id="role"
                           type="text"
                           required
                           className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
@@ -155,7 +157,7 @@ export default function AddApplicationModal({
                   </div>
 
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                    <label htmlFor="location" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                       Location
                     </label>
                     <div className="relative">
@@ -164,6 +166,7 @@ export default function AddApplicationModal({
                         className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                       />
                       <input
+                        id="location"
                         type="text"
                         className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
                         placeholder="e.g. Remote, TX"
@@ -176,7 +179,7 @@ export default function AddApplicationModal({
                   </div>
 
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                    <label htmlFor="apply_url" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                       Job Link
                     </label>
                     <div className="relative">
@@ -185,6 +188,7 @@ export default function AddApplicationModal({
                         className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                       />
                       <input
+                        id="apply_url"
                         type="url"
                         className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
                         placeholder="https://..."
@@ -203,7 +207,7 @@ export default function AddApplicationModal({
                     <button
                       type="button"
                       onClick={onClose}
-                      className="flex-1 px-6 py-3 rounded-2xl border border-slate-100 dark:border-slate-800 font-bold text-sm dark: transition-all"
+                      className="flex-1 px-6 py-3 rounded-2xl border border-slate-100 dark:border-slate-800 font-bold text-sm transition-all"
                     >
                       Cancel
                     </button>

--- a/frontend/components/dashboard/OnboardingWizard.tsx
+++ b/frontend/components/dashboard/OnboardingWizard.tsx
@@ -198,10 +198,11 @@ export default function OnboardingWizard({
 
             <div className="space-y-6 bg-white/5 border border-white/10 p-8 rounded-[32px] backdrop-blur-xl">
               <div>
-                <label className="block text-sm font-bold text-slate-300 mb-2 uppercase tracking-wide">
+                <label htmlFor="target-role" className="block text-sm font-bold text-slate-300 mb-2 uppercase tracking-wide">
                   Target Role
                 </label>
                 <input
+                  id="target-role"
                   value={role}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                     setRole(e.target.value)
@@ -211,10 +212,11 @@ export default function OnboardingWizard({
                 />
               </div>
               <div>
-                <label className="block text-sm font-bold text-slate-300 mb-2 uppercase tracking-wide">
+                <label htmlFor="dream-company" className="block text-sm font-bold text-slate-300 mb-2 uppercase tracking-wide">
                   Dream Company (Optional)
                 </label>
                 <input
+                  id="dream-company"
                   value={company}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                     setCompany(e.target.value)


### PR DESCRIPTION
### 💡 What
Added `htmlFor` attributes to `<label>` elements and matching `id` attributes to `<input>` elements in `AddApplicationModal` and `OnboardingWizard`. Removed malformed isolated `dark:` tailwind classes.

### 🎯 Why
Without `htmlFor` and `id` pairings, clicking the label text doesn't focus the input, and screen readers cannot correctly announce the label when the input is focused, degrading accessibility.

### 📸 Before/After
No visual changes, but clicking labels now focuses the corresponding inputs.

### ♿ Accessibility
Forms are now properly semantic, enabling click-to-focus and screen reader association for inputs.

---
*PR created automatically by Jules for task [11910993296722024501](https://jules.google.com/task/11910993296722024501) started by @SudoAnirudh*