### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent Information Disclosure in HTTP Exceptions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** OS-level file operations (like `os.remove`) during cleanup were only catching `FileNotFoundError`. Other exceptions could propagate and leak internal paths or stack traces in 500 responses.
 **Learning:** System operations can fail for many reasons (e.g., permissions, locks). Unhandled exceptions in cleanup routines break the "fail securely" principle and risk information disclosure.
 **Prevention:** Always catch broad exceptions like `Exception` in cleanup/teardown routines, log them securely, and prevent them from propagating to the client.
+## 2025-01-09 - [Prevent Information Disclosure in HTTP Exceptions]
+**Vulnerability:** Raw exception strings (e.g., `str(e)`) were being exposed to clients in `HTTPException` responses in `jobs_board.py` and `interview.py`.
+**Learning:** Exposing raw exceptions can leak internal stack traces, system paths, or other sensitive information, which violates the "fail securely" principle.
+**Prevention:** Catch exceptions, log the detailed error internally using a logger, and return a sanitized, generic error message in the `HTTPException` detail field.

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -390,7 +390,7 @@ async def transcribe(
         return {"text": text}
     except Exception as e:
         logger.error(f"Transcription route failure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Transcription failed.")
 
 
 @router.post("/next-question", response_model=InterviewQuestion)

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -78,4 +78,5 @@ async def trigger_jobs_sync(
         new_jobs = await sync_twitter_jobs()
         return {"status": "success", "message": f"Sync complete. Added {new_jobs} jobs."}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Error during jobs sync: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error during jobs sync.")


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Raw exception strings (e.g., `str(e)`) were being exposed to clients in `HTTPException` responses in `backend/routers/jobs_board.py` and `backend/routers/interview.py`.
🎯 **Impact:** Exposing raw exceptions can leak internal stack traces, system paths, or other sensitive information, violating the "fail securely" principle and providing attackers with reconnaissance data.
🔧 **Fix:** Caught exceptions, logged the detailed error internally using a logger, and returned sanitized, generic error messages in the `HTTPException` detail fields.
✅ **Verification:** Verified by running the backend test suite successfully. Evaluated the modified files manually using `sed`. Also updated the Sentinel journal.

---
*PR created automatically by Jules for task [17595665506031524817](https://jules.google.com/task/17595665506031524817) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error responses for transcription and jobs synchronization failures.
  - Replaced potentially sensitive technical details with clear, generic messages.
  - Errors are now recorded internally for troubleshooting while keeping response details safe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->