### PR TITLE
⚡ Bolt: Optimize export_cover_letter endpoint

### DIFF
--- a/backend/routers/cover_letter.py
+++ b/backend/routers/cover_letter.py
@@ -1,5 +1,6 @@
 import uuid
 import datetime
+import asyncio
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from dependencies import get_current_user, get_supabase_admin
@@ -93,26 +94,31 @@ async def export_cover_letter(
     db=Depends(get_supabase_admin),
 ):
     """Exports a cover letter as PDF or Docx."""
-    r = (
-        db.table("cover_letters")
+
+    # What: Uses asyncio.gather and asyncio.to_thread to execute Supabase queries concurrently.
+    # Why: The Supabase python client is synchronous; calling .execute() in series blocks the async event loop and increases latency.
+    cover_letter_task = asyncio.to_thread(
+        lambda: db.table("cover_letters")
         .select("*")
         .eq("id", letter_id)
         .eq("user_id", user["user_id"])
         .single()
         .execute()
     )
-    if not r.data:
-        raise HTTPException(status_code=404, detail="Cover letter not found.")
 
-    # Fetch user profile for headers
-    p = (
-        db.table("profiles")
+    profile_task = asyncio.to_thread(
+        lambda: db.table("profiles")
         .select("full_name")
         .eq("id", user["user_id"])
         .single()
         .execute()
     )
     
+    r, p = await asyncio.gather(cover_letter_task, profile_task)
+
+    if not r.data:
+        raise HTTPException(status_code=404, detail="Cover letter not found.")
+
     header_info = {
         "name": p.data.get("full_name", "Valued User"),
         "email": user.get("email", ""),


### PR DESCRIPTION
**💡 What:**
Optimized the `export_cover_letter` endpoint in `backend/routers/cover_letter.py` by using `asyncio.gather` and `asyncio.to_thread` to run independent Supabase queries (`cover_letters` and `profiles`) concurrently instead of sequentially.

**🎯 Why:**
The Supabase Python client is synchronous. In a FastAPI async route, running multiple `.execute()` queries in series blocks the async event loop, reducing the server's throughput and increasing response latency. Executing independent queries concurrently significantly mitigates this bottleneck.

**📊 Impact:**
Expected to reduce the latency of the `/export/{letter_id}` endpoint by running two database queries in parallel, effectively cutting the database I/O time for this endpoint roughly in half on the happy path.

**🔬 Measurement:**
Can be verified by monitoring the endpoint latency or running a load test against the `/export/{letter_id}` route to observe improved response times.

---
*PR created automatically by Jules for task [3897667169595824207](https://jules.google.com/task/3897667169595824207) started by @SudoAnirudh*