### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Exception Information Disclosure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** OS-level file operations (like `os.remove`) during cleanup were only catching `FileNotFoundError`. Other exceptions could propagate and leak internal paths or stack traces in 500 responses.
 **Learning:** System operations can fail for many reasons (e.g., permissions, locks). Unhandled exceptions in cleanup routines break the "fail securely" principle and risk information disclosure.
 **Prevention:** Always catch broad exceptions like `Exception` in cleanup/teardown routines, log them securely, and prevent them from propagating to the client.
+## 2025-01-08 - [Fail Securely: Exception String Leakage in FastAPI]
+**Vulnerability:** Raw exception strings (`str(e)`) were being returned directly to clients via `HTTPException` details, which could expose internal system state, stack traces, or other sensitive information.
+**Learning:** Returning `str(e)` in APIs violates the "fail securely" principle by risking information disclosure.
+**Prevention:** Always log the detailed error internally using a logger (`logger.error(f"... {e}")`) and return a sanitized, generic error message in the `HTTPException`.

--- a/backend/routers/agent.py
+++ b/backend/routers/agent.py
@@ -123,7 +123,7 @@ async def chat_with_agent(req: ChatRequest, user: Dict[str, Any] = Depends(get_c
         logger.error(f"Error in agentic chat route: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Agent execution failed: {str(e)}"
+            detail="An internal error occurred during agent execution."
         )
 
 
@@ -206,7 +206,7 @@ async def resolve_approval(req: ApproveRequest, user: Dict[str, Any] = Depends(g
         logger.error(f"Error resuming graph execution: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Resuming agent execution failed: {str(e)}"
+            detail="An internal error occurred while resuming agent execution."
         )
 
 

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -390,7 +390,7 @@ async def transcribe(
         return {"text": text}
     except Exception as e:
         logger.error(f"Transcription route failure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="An internal error occurred during transcription.")
 
 
 @router.post("/next-question", response_model=InterviewQuestion)

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -78,4 +78,5 @@ async def trigger_jobs_sync(
         new_jobs = await sync_twitter_jobs()
         return {"status": "success", "message": f"Sync complete. Added {new_jobs} jobs."}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Error syncing jobs: {e}")
+        raise HTTPException(status_code=500, detail="An internal error occurred during job sync.")


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Information Disclosure. Raw exception strings (`str(e)`) were being passed to `HTTPException` detail fields and returned directly to the client on 500 errors. This violates the "fail securely" principle and could leak internal system state, file paths, external API URLs, or stack traces depending on the underlying failure.
🎯 Impact: An attacker could intentionally trigger errors to map out internal infrastructure or gain context for further attacks.
🔧 Fix: Removed `str(e)` from the `HTTPException` detail across multiple routers. Added or maintained internal `logger.error` statements to ensure the full error context is still captured in server logs, while returning a generic sanitized message to the client.
✅ Verification: Ran `pytest` backend tests to ensure route syntax and functionality remained intact. Inspected the modified files via `sed` to verify correct implementation.

---
*PR created automatically by Jules for task [7695650179324675664](https://jules.google.com/task/7695650179324675664) started by @SudoAnirudh*