### PR TITLE
🎨 Palette: Fix form accessibility in AddApplicationModal

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-22 - Add htmlFor and id to form labels
+**Learning:** Many form inputs lack proper `<label>` association which breaks click-to-focus and screen reader announcements.
+**Action:** Systematically verify and add `htmlFor` to `<label>` elements and matching `id` attributes to corresponding `<input>` elements.

--- a/frontend/components/dashboard/AddApplicationModal.tsx
+++ b/frontend/components/dashboard/AddApplicationModal.tsx
@@ -85,7 +85,7 @@ export default function AddApplicationModal({
                 <button
                   onClick={onClose}
                   aria-label="Close modal"
-                  className="absolute top-6 right-6 p-2 rounded-full dark: text-slate-400 transition-colors"
+                  className="absolute top-6 right-6 p-2 rounded-full text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
                 >
                   <X size={20} />
                 </button>
@@ -107,7 +107,7 @@ export default function AddApplicationModal({
                 <form onSubmit={handleSubmit} className="space-y-6">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div className="space-y-2">
-                      <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                      <label htmlFor="company" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                         Company
                       </label>
                       <div className="relative">
@@ -116,6 +116,7 @@ export default function AddApplicationModal({
                           className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                         />
                         <input
+                          id="company"
                           type="text"
                           required
                           className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
@@ -132,7 +133,7 @@ export default function AddApplicationModal({
                     </div>
 
                     <div className="space-y-2">
-                      <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                      <label htmlFor="role" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                         Role
                       </label>
                       <div className="relative">
@@ -141,6 +142,7 @@ export default function AddApplicationModal({
                           className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                         />
                         <input
+                          id="role"
                           type="text"
                           required
                           className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
@@ -155,7 +157,7 @@ export default function AddApplicationModal({
                   </div>
 
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                    <label htmlFor="location" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                       Location
                     </label>
                     <div className="relative">
@@ -164,6 +166,7 @@ export default function AddApplicationModal({
                         className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                       />
                       <input
+                        id="location"
                         type="text"
                         className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
                         placeholder="e.g. Remote, TX"
@@ -176,7 +179,7 @@ export default function AddApplicationModal({
                   </div>
 
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                    <label htmlFor="apply_url" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                       Job Link
                     </label>
                     <div className="relative">
@@ -185,6 +188,7 @@ export default function AddApplicationModal({
                         className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                       />
                       <input
+                        id="apply_url"
                         type="url"
                         className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
                         placeholder="https://..."
@@ -203,7 +207,7 @@ export default function AddApplicationModal({
                     <button
                       type="button"
                       onClick={onClose}
-                      className="flex-1 px-6 py-3 rounded-2xl border border-slate-100 dark:border-slate-800 font-bold text-sm dark: transition-all"
+                      className="flex-1 px-6 py-3 rounded-2xl border border-slate-100 dark:border-slate-800 font-bold text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-all"
                     >
                       Cancel
                     </button>


### PR DESCRIPTION
💡 **What**: Added `htmlFor` and `id` pairings to the inputs in `AddApplicationModal`. Also fixed malformed `dark:` classes on buttons.
🎯 **Why**: Many form inputs lacked proper `<label>` association which breaks click-to-focus and screen reader announcements.
📸 **Before/After**: Click-to-focus now works on the Company, Role, Location, and Job Link labels. Hover states on the Close and Cancel buttons now render correctly in dark mode.
♿ **Accessibility**: Improved form field navigation for screen readers and keyboard users.

---
*PR created automatically by Jules for task [3414085615937790472](https://jules.google.com/task/3414085615937790472) started by @SudoAnirudh*