### PR TITLE
🎨 Palette: Add htmlFor to form labels for screen reader support

### DIFF
--- a/frontend/app/dashboard/job-match/page.tsx
+++ b/frontend/app/dashboard/job-match/page.tsx
@@ -658,11 +658,12 @@ export default function JobMatchPage() {
           </h3>
           <div className="p-8 md:p-10 rounded-[2.5rem] bg-slate-50/50 dark:bg-slate-900/40 border border-slate-100 dark:border-slate-800/80 shadow-lg backdrop-blur-md grid grid-cols-1 sm:grid-cols-2 md:grid-cols-5 gap-6 items-end">
             <div className="space-y-3">
-              <label className="text-[10px] font-black uppercase tracking-widest text-muted-foreground">
+              <label htmlFor="specialization" className="text-[10px] font-black uppercase tracking-widest text-muted-foreground">
                 Specialization
               </label>
               <div className="relative">
                 <input
+                  id="specialization"
                   className="w-full bg-white/60 border border-slate-200/50 rounded-2xl pl-10 pr-4 h-12 text-xs font-bold outline-none text-foreground transition-all focus:border-brand-blue focus:ring-2 focus:ring-brand-blue/20"
                   placeholder="e.g. React, LLM, Python..."
                   value={fieldInput}
@@ -674,11 +675,12 @@ export default function JobMatchPage() {
               </div>
             </div>
             <div className="space-y-3">
-              <label className="text-[10px] font-black uppercase tracking-widest text-muted-foreground">
+              <label htmlFor="geo-preference" className="text-[10px] font-black uppercase tracking-widest text-muted-foreground">
                 Geo Preference
               </label>
               <div className="relative">
                 <input
+                  id="geo-preference"
                   className="w-full bg-white/60 border border-slate-200/50 rounded-2xl pl-10 pr-4 h-12 text-xs font-bold outline-none text-foreground transition-all focus:border-brand-blue focus:ring-2 focus:ring-brand-blue/20"
                   placeholder="e.g. India, Bangalore..."
                   value={jobLocation}
@@ -690,11 +692,12 @@ export default function JobMatchPage() {
               </div>
             </div>
             <div className="space-y-3 relative">
-              <label className="text-[10px] font-black uppercase tracking-widest text-muted-foreground">
+              <label htmlFor="workplace" className="text-[10px] font-black uppercase tracking-widest text-muted-foreground">
                 Workplace
               </label>
               <div className="relative">
                 <select
+                  id="workplace"
                   className="w-full bg-white/60 border border-slate-200/50 rounded-2xl pl-4 pr-10 h-12 text-xs font-bold outline-none text-foreground cursor-pointer appearance-none transition-all focus:border-brand-blue focus:ring-2 focus:ring-brand-blue/20"
                   value={workplaceType}
                   onChange={(e) => setWorkplaceType(e.target.value)}
@@ -710,11 +713,12 @@ export default function JobMatchPage() {
               </div>
             </div>
             <div className="space-y-3 relative">
-              <label className="text-[10px] font-black uppercase tracking-widest text-muted-foreground">
+              <label htmlFor="job-type" className="text-[10px] font-black uppercase tracking-widest text-muted-foreground">
                 Job Type
               </label>
               <div className="relative">
                 <select
+                  id="job-type"
                   className="w-full bg-white/60 border border-slate-200/50 rounded-2xl pl-4 pr-10 h-12 text-xs font-bold outline-none text-foreground cursor-pointer appearance-none transition-all focus:border-brand-blue focus:ring-2 focus:ring-brand-blue/20"
                   value={jobType}
                   onChange={(e) => setJobType(e.target.value)}

--- a/frontend/app/dashboard/roadmap/page.tsx
+++ b/frontend/app/dashboard/roadmap/page.tsx
@@ -130,7 +130,7 @@ export default function RoadmapPage() {
 
     // Flatten all completed skills for the backend
     const getCompletedNames = (skills: RoadmapSkill[]): string[] => {
-      let names: string[] = [];
+      const names: string[] = [];
       skills.forEach((s) => {
         if (s.status === "completed") names.push(s.name);
         if (s.children) names.push(...getCompletedNames(s.children));

--- a/frontend/components/dashboard/AddApplicationModal.tsx
+++ b/frontend/components/dashboard/AddApplicationModal.tsx
@@ -107,7 +107,7 @@ export default function AddApplicationModal({
                 <form onSubmit={handleSubmit} className="space-y-6">
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div className="space-y-2">
-                      <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                      <label htmlFor="company" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                         Company
                       </label>
                       <div className="relative">
@@ -116,6 +116,7 @@ export default function AddApplicationModal({
                           className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                         />
                         <input
+                          id="company"
                           type="text"
                           required
                           className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
@@ -132,7 +133,7 @@ export default function AddApplicationModal({
                     </div>
 
                     <div className="space-y-2">
-                      <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                      <label htmlFor="role" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                         Role
                       </label>
                       <div className="relative">
@@ -141,6 +142,7 @@ export default function AddApplicationModal({
                           className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                         />
                         <input
+                          id="role"
                           type="text"
                           required
                           className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
@@ -155,7 +157,7 @@ export default function AddApplicationModal({
                   </div>
 
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                    <label htmlFor="location" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                       Location
                     </label>
                     <div className="relative">
@@ -164,6 +166,7 @@ export default function AddApplicationModal({
                         className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                       />
                       <input
+                        id="location"
                         type="text"
                         className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
                         placeholder="e.g. Remote, TX"
@@ -176,7 +179,7 @@ export default function AddApplicationModal({
                   </div>
 
                   <div className="space-y-2">
-                    <label className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
+                    <label htmlFor="job-link" className="text-[10px] font-black uppercase tracking-widest text-[#64748B] ml-1">
                       Job Link
                     </label>
                     <div className="relative">
@@ -185,6 +188,7 @@ export default function AddApplicationModal({
                         className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-400"
                       />
                       <input
+                        id="job-link"
                         type="url"
                         className="w-full pl-12 pr-4 py-3 bg-slate-50 dark:bg-slate-800/50 border border-slate-100 dark:border-slate-800 rounded-2xl focus:outline-none focus:ring-2 focus:ring-indigo-500/20 transition-all text-sm"
                         placeholder="https://..."


### PR DESCRIPTION
## 💡 What
Added `htmlFor` attributes to `<label>` elements and matching `id` attributes to their corresponding `<input>` and `<select>` elements in the Job Match Discovery page and the Add Application modal.

## 🎯 Why
React form labels in these components frequently omitted the `htmlFor` attribute. Adding these pairings ensures that clicking the label correctly focuses the associated input, and guarantees that screen readers properly announce the label when the input is focused, significantly improving usability and accessibility.

## 📸 Before/After
N/A (Non-visual DOM structure change)

## ♿ Accessibility
- Added `htmlFor` and `id` pairings to ensure full compliance with WCAG 1.3.1 (Info and Relationships) and 4.1.2 (Name, Role, Value).
- Screen readers will now reliably associate the visible labels with their respective form controls, enabling keyboard and non-visual users to navigate and understand the forms properly.

---
*PR created automatically by Jules for task [4443398357025269699](https://jules.google.com/task/4443398357025269699) started by @SudoAnirudh*