### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent information disclosure via exception leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** OS-level file operations (like `os.remove`) during cleanup were only catching `FileNotFoundError`. Other exceptions could propagate and leak internal paths or stack traces in 500 responses.
 **Learning:** System operations can fail for many reasons (e.g., permissions, locks). Unhandled exceptions in cleanup routines break the "fail securely" principle and risk information disclosure.
 **Prevention:** Always catch broad exceptions like `Exception` in cleanup/teardown routines, log them securely, and prevent them from propagating to the client.
+## 2024-05-24 - Do not leak exception details in FastAPI 500 errors
+**Vulnerability:** Information Disclosure
+**Learning:** Exception details passed to HTTPException(`detail=str(e)`) leak internal application workings directly to the client, providing attackers with sensitive information.
+**Prevention:** Catch generic exceptions, log them securely internally, and provide a generic response to the client.

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -390,7 +390,7 @@ async def transcribe(
         return {"text": text}
     except Exception as e:
         logger.error(f"Transcription route failure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Transcription service failed.")
 
 
 @router.post("/next-question", response_model=InterviewQuestion)

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -78,4 +78,5 @@ async def trigger_jobs_sync(
         new_jobs = await sync_twitter_jobs()
         return {"status": "success", "message": f"Sync complete. Added {new_jobs} jobs."}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Error syncing twitter jobs: {e}")
+        raise HTTPException(status_code=500, detail="An internal server error occurred during job sync.")


### PR DESCRIPTION
🚨 **Severity**: MEDIUM

💡 **Vulnerability**: Information Disclosure (Exception detail leakage)
The `/trigger-twitter-jobs-sync` and `/upload-audio` routes were directly catching generic `Exception`s and returning `str(e)` in the `HTTPException` detail. This leaks internal application workings and potentially sensitive information to the client in the event of a 500 error.

🎯 **Impact**: An attacker could deliberately trigger errors in these routes to gain insight into the application's internal structure, backend services, or data formatting, aiding in further attacks.

🔧 **Fix**: Modified the exception handlers to log the raw exception `str(e)` securely via the internal `logger` and raise the 500 `HTTPException` with a generic, sanitized error message (e.g., "Transcription service failed").

✅ **Verification**:
- Verified changes in `backend/routers/jobs_board.py` and `backend/routers/interview.py`.
- Ran the backend test suite successfully (`pytest backend/tests/`).
- Added entry to `.jules/sentinel.md` documenting the learning.

---
*PR created automatically by Jules for task [2483480300370345212](https://jules.google.com/task/2483480300370345212) started by @SudoAnirudh*