### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent Information Disclosure in HTTP Responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** OS-level file operations (like `os.remove`) during cleanup were only catching `FileNotFoundError`. Other exceptions could propagate and leak internal paths or stack traces in 500 responses.
 **Learning:** System operations can fail for many reasons (e.g., permissions, locks). Unhandled exceptions in cleanup routines break the "fail securely" principle and risk information disclosure.
 **Prevention:** Always catch broad exceptions like `Exception` in cleanup/teardown routines, log them securely, and prevent them from propagating to the client.
+## 2025-01-20 - [Information Disclosure via Exception Propagation]
+**Vulnerability:** Raw exception details (`str(e)`) were exposed to clients in `HTTPException` 500 responses across several FastAPI routers.
+**Learning:** Exposing raw exceptions breaks the "fail securely" principle and risks leaking sensitive internal information, such as file paths, database state, or third-party API issues.
+**Prevention:** Always log detailed exceptions on the server-side using a logger, and return sanitized, generic error messages to the client.

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -390,7 +390,7 @@ async def transcribe(
         return {"text": text}
     except Exception as e:
         logger.error(f"Transcription route failure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="An error occurred during transcription.")
 
 
 @router.post("/next-question", response_model=InterviewQuestion)

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -78,4 +78,5 @@ async def trigger_jobs_sync(
         new_jobs = await sync_twitter_jobs()
         return {"status": "success", "message": f"Sync complete. Added {new_jobs} jobs."}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Error during job sync: {e}")
+        raise HTTPException(status_code=500, detail="An error occurred during job synchronization.")


### PR DESCRIPTION
- 🚨 Severity: MEDIUM
- 💡 Vulnerability: Information Disclosure - raw exception details (`str(e)`) were being leaked to the client in 500 Internal Server Error responses in `jobs_board.py` and `interview.py`.
- 🎯 Impact: Attackers could gain insights into internal system state, file paths, database structure, or API keys from stack traces and exception messages.
- 🔧 Fix: Replaced raw exception details with generic error messages and ensured exceptions are securely logged on the server.
- ✅ Verification: Ensured the codebase no longer contains `HTTPException(status_code=500, detail=str(e))` by modifying `jobs_board.py` and `interview.py` and running the test suite. Updated the Sentinel journal.

---
*PR created automatically by Jules for task [3772746791853264878](https://jules.google.com/task/3772746791853264878) started by @SudoAnirudh*