### PR TITLE
🎨 Palette: Improve accessibility of interview action buttons

### DIFF
--- a/frontend/app/dashboard/roadmap/page.tsx
+++ b/frontend/app/dashboard/roadmap/page.tsx
@@ -130,7 +130,7 @@ export default function RoadmapPage() {
 
     // Flatten all completed skills for the backend
     const getCompletedNames = (skills: RoadmapSkill[]): string[] => {
-      let names: string[] = [];
+      const names: string[] = [];
       skills.forEach((s) => {
         if (s.status === "completed") names.push(s.name);
         if (s.children) names.push(...getCompletedNames(s.children));

--- a/frontend/components/InterviewPanel.tsx
+++ b/frontend/components/InterviewPanel.tsx
@@ -803,12 +803,14 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
             type="button"
             onClick={toggleListening}
             disabled={!speechSupported || submitting || transcribing}
-            className={`p-3.5 rounded-full transition-all active:scale-90 ${
+            className={`p-3.5 rounded-full transition-all active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
               isListening
                 ? "bg-red-500 hover:bg-red-600 text-white shadow-lg shadow-red-500/20"
                 : "bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
             } disabled:opacity-50`}
             title={isListening ? "Mute Microphone" : "Unmute Microphone"}
+            aria-label={isListening ? "Mute Microphone" : "Unmute Microphone"}
+            aria-pressed={isListening}
           >
             {isListening ? <Mic size={18} /> : <MicOff size={18} />}
           </button>
@@ -818,12 +820,14 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
             type="button"
             onClick={() => setCameraOn(!cameraOn)}
             disabled={submitting || transcribing}
-            className={`p-3.5 rounded-full transition-all active:scale-90 ${
+            className={`p-3.5 rounded-full transition-all active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
               cameraOn
                 ? "bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
                 : "bg-red-500 hover:bg-red-600 text-white shadow-lg shadow-red-500/20"
             }`}
             title={cameraOn ? "Stop Video" : "Start Video"}
+            aria-label={cameraOn ? "Stop Video" : "Start Video"}
+            aria-pressed={cameraOn}
           >
             {cameraOn ? <Video size={18} /> : <VideoOff size={18} />}
           </button>
@@ -854,8 +858,9 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
             <button
               type="button"
               onClick={onExit}
-              className="p-3.5 rounded-full bg-slate-800 hover:bg-slate-700 text-red-400 border border-slate-700 transition-all active:scale-90"
+              className="p-3.5 rounded-full bg-slate-800 hover:bg-slate-700 text-red-400 border border-slate-700 transition-all active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
               title="Hang Up / Exit Interview"
+              aria-label="Hang Up / Exit Interview"
             >
               <PhoneOff size={18} />
             </button>


### PR DESCRIPTION
## 💡 What
Added explicit `aria-label`, `aria-pressed`, and `focus-visible` ring utility classes to the icon-only toggle buttons in the Interview Panel (Mic, Camera, Hang Up).

## 🎯 Why
Screen readers need explicit ARIA labels on icon-only buttons to convey their purpose, and keyboard users rely on focus rings to see which element is currently focused. Toggle states need `aria-pressed` for clarity.

## 📸 Before/After
*No structural visual change, except for visible focus rings when navigating via keyboard.*

## ♿ Accessibility
- Improved screen reader context by pairing `title` with explicit `aria-label`.
- Conveyed active toggle state to screen readers using `aria-pressed`.
- Provided a high-contrast visual focus ring for keyboard navigation.

---
*PR created automatically by Jules for task [14935816655801077297](https://jules.google.com/task/14935816655801077297) started by @SudoAnirudh*