### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure via Exception Leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** OS-level file operations (like `os.remove`) during cleanup were only catching `FileNotFoundError`. Other exceptions could propagate and leak internal paths or stack traces in 500 responses.
 **Learning:** System operations can fail for many reasons (e.g., permissions, locks). Unhandled exceptions in cleanup routines break the "fail securely" principle and risk information disclosure.
 **Prevention:** Always catch broad exceptions like `Exception` in cleanup/teardown routines, log them securely, and prevent them from propagating to the client.
+## 2024-07-27 - Information Disclosure via Exception Leakage
+**Vulnerability:** FastApi routers exposed raw exception strings (e.g., `detail=str(e)`) to the client.
+**Learning:** Exposing detailed exception strings can leak internal system architecture or stack traces to an attacker.
+**Prevention:** Log the raw exception detail on the backend (`logger.error`) but return a sanitized, generic error message (e.g., `detail="Internal error"`) to the client via `HTTPException`.

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -390,7 +390,7 @@ async def transcribe(
         return {"text": text}
     except Exception as e:
         logger.error(f"Transcription route failure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="An internal error occurred during transcription.")
 
 
 @router.post("/next-question", response_model=InterviewQuestion)

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -78,4 +78,5 @@ async def trigger_jobs_sync(
         new_jobs = await sync_twitter_jobs()
         return {"status": "success", "message": f"Sync complete. Added {new_jobs} jobs."}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Error during Twitter sync: {e}")
+        raise HTTPException(status_code=500, detail="An internal error occurred during sync.")


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Raw exception strings were being exposed to the client in HTTPException details, potentially leaking internal system architecture.
🎯 Impact: An attacker could gain insight into the system's backend by inducing errors and reading the exposed stack traces or exception details.
🔧 Fix: Sanitized error messages sent to the client and ensured actual exception details are logged securely on the backend.
✅ Verification: Run backend tests to ensure the endpoints continue to work but no longer leak internal error strings on failure.

---
*PR created automatically by Jules for task [11531693161798461825](https://jules.google.com/task/11531693161798461825) started by @SudoAnirudh*