### PR TITLE
⚡ Bolt: Optimize export_cover_letter endpoint in cover_letter.py

### DIFF
--- a/backend/routers/cover_letter.py
+++ b/backend/routers/cover_letter.py
@@ -1,5 +1,6 @@
 import uuid
 import datetime
+import asyncio
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from dependencies import get_current_user, get_supabase_admin
@@ -93,25 +94,14 @@ async def export_cover_letter(
     db=Depends(get_supabase_admin),
 ):
     """Exports a cover letter as PDF or Docx."""
-    r = (
-        db.table("cover_letters")
-        .select("*")
-        .eq("id", letter_id)
-        .eq("user_id", user["user_id"])
-        .single()
-        .execute()
-    )
+    # ⚡ Bolt: Execute independent queries concurrently to prevent event loop blocking and reduce endpoint latency.
+    r_task = asyncio.to_thread(lambda: db.table("cover_letters").select("*").eq("id", letter_id).eq("user_id", user["user_id"]).single().execute())
+    p_task = asyncio.to_thread(lambda: db.table("profiles").select("full_name").eq("id", user["user_id"]).single().execute())
+
+    r, p = await asyncio.gather(r_task, p_task)
+
     if not r.data:
         raise HTTPException(status_code=404, detail="Cover letter not found.")
-
-    # Fetch user profile for headers
-    p = (
-        db.table("profiles")
-        .select("full_name")
-        .eq("id", user["user_id"])
-        .single()
-        .execute()
-    )
     
     header_info = {
         "name": p.data.get("full_name", "Valued User"),


### PR DESCRIPTION
💡 What: Wrapped synchronous Supabase `.execute()` queries in `asyncio.to_thread` and executed them concurrently using `asyncio.gather`.
🎯 Why: The Supabase Python client is synchronous. Running multiple `.execute()` calls sequentially in an async FastAPI route blocks the event loop and increases latency.
📊 Impact: Reduces endpoint latency by executing the cover letter and profile queries concurrently, and prevents blocking the main thread for other concurrent requests.
🔬 Measurement: Verify by measuring the response time of the `/export/{letter_id}` endpoint before and after the change; it should reflect the duration of the single longest query rather than the sum of both.

---
*PR created automatically by Jules for task [14399513928321014027](https://jules.google.com/task/14399513928321014027) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved cover letter export responsiveness by running required data lookups concurrently.
  * Preserved existing behavior when a requested cover letter cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->