### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Disclosure in Error Handling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** OS-level file operations (like `os.remove`) during cleanup were only catching `FileNotFoundError`. Other exceptions could propagate and leak internal paths or stack traces in 500 responses.
 **Learning:** System operations can fail for many reasons (e.g., permissions, locks). Unhandled exceptions in cleanup routines break the "fail securely" principle and risk information disclosure.
 **Prevention:** Always catch broad exceptions like `Exception` in cleanup/teardown routines, log them securely, and prevent them from propagating to the client.
+## 2024-05-18 - Prevent Information Disclosure in HTTPException
+**Vulnerability:** Raw exception strings (e.g., `str(e)`) were passed directly to FastAPI's `HTTPException(detail=...)`, exposing internal stack traces or error details to the client.
+**Learning:** Returning unhandled exception details directly in HTTP responses can leak sensitive system architecture, database schema, or operational details.
+**Prevention:** Always log the full exception internally (e.g., `logger.error(...)`) and return a generic, sanitized error message in the `HTTPException` detail field.

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -390,7 +390,7 @@ async def transcribe(
         return {"text": text}
     except Exception as e:
         logger.error(f"Transcription route failure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="An error occurred during transcription.")
 
 
 @router.post("/next-question", response_model=InterviewQuestion)

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -78,4 +78,5 @@ async def trigger_jobs_sync(
         new_jobs = await sync_twitter_jobs()
         return {"status": "success", "message": f"Sync complete. Added {new_jobs} jobs."}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Jobs sync route failure: {e}")
+        raise HTTPException(status_code=500, detail="An error occurred during jobs sync.")


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Raw exception strings (`str(e)`) were being passed directly to the client via `HTTPException(detail=...)` in `jobs_board.py` and `interview.py`, which could leak sensitive system or database details.
🎯 Impact: Attackers could gain insight into internal system architecture or stack traces from unhandled exceptions.
🔧 Fix: Removed `detail=str(e)`, logged the full exception using `logger.error`, and returned generic sanitized error messages to the client.
✅ Verification: Ran `pytest` backend tests to ensure the endpoints still function without raising errors. Tested that exceptions now return standard messages instead of raw strings.

---
*PR created automatically by Jules for task [4914753685123099928](https://jules.google.com/task/4914753685123099928) started by @SudoAnirudh*