### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent Information Leakage in API Exceptions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,8 @@
 **Vulnerability:** OS-level file operations (like `os.remove`) during cleanup were only catching `FileNotFoundError`. Other exceptions could propagate and leak internal paths or stack traces in 500 responses.
 **Learning:** System operations can fail for many reasons (e.g., permissions, locks). Unhandled exceptions in cleanup routines break the "fail securely" principle and risk information disclosure.
 **Prevention:** Always catch broad exceptions like `Exception` in cleanup/teardown routines, log them securely, and prevent them from propagating to the client.
+
+## 2024-05-24 - Prevent Information Leakage in APIs
+**Vulnerability:** Exception details (str(e)) were exposed directly to the client via HTTPException(detail=...).
+**Learning:** Exposing internal error stack traces or raw error strings through API endpoints can reveal sensitive structural info or paths to attackers.
+**Prevention:** Always log the full exception internally (using `logger.error`) but return a generic, sanitized HTTP error message to the client.

--- a/backend/routers/agent.py
+++ b/backend/routers/agent.py
@@ -1,10 +1,9 @@
 import logging
-import uuid
 from typing import Dict, Any, Optional, Literal
 from pydantic import BaseModel
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from langchain_core.messages import HumanMessage, AIMessage
+from langchain_core.messages import HumanMessage
 
 from dependencies import get_current_user, get_supabase_admin
 from services.agentic.supervisor import get_compiled_graph
@@ -123,7 +122,7 @@ async def chat_with_agent(req: ChatRequest, user: Dict[str, Any] = Depends(get_c
         logger.error(f"Error in agentic chat route: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Agent execution failed: {str(e)}"
+            detail="Agent execution failed due to an internal error."
         )
 
 
@@ -206,7 +205,7 @@ async def resolve_approval(req: ApproveRequest, user: Dict[str, Any] = Depends(g
         logger.error(f"Error resuming graph execution: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Resuming agent execution failed: {str(e)}"
+            detail="Resuming agent execution failed due to an internal error."
         )
 
 

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 from typing import Dict, List
 from fastapi import APIRouter, Depends, HTTPException, File, UploadFile
+from fastapi.responses import StreamingResponse
 from dependencies import get_current_user, get_supabase_admin
 from services.interview_engine import (
     generate_questions,
@@ -390,7 +391,7 @@ async def transcribe(
         return {"text": text}
     except Exception as e:
         logger.error(f"Transcription route failure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Transcription failed due to an internal error.")
 
 
 @router.post("/next-question", response_model=InterviewQuestion)

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -78,4 +78,5 @@ async def trigger_jobs_sync(
         new_jobs = await sync_twitter_jobs()
         return {"status": "success", "message": f"Sync complete. Added {new_jobs} jobs."}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Sync failed: {e}")
+        raise HTTPException(status_code=500, detail="An error occurred while syncing jobs.")


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Exception details (str(e)) were exposed directly to the client via HTTPException(detail=...) in several routes (`/sync`, `/transcribe`, `/chat`, and `/approve`).
🎯 Impact: Exposing internal error stack traces or raw error strings through API endpoints can reveal sensitive structural info or paths to attackers.
🔧 Fix: Removed `str(e)` from the `HTTPException` responses. Always log the full exception internally (using `logger.error`) but return a generic, sanitized HTTP error message to the client.
✅ Verification: Ran `pytest` on backend to ensure all tests pass. Linted code using `flake8`. All tests pass and there's no syntax errors.

---
*PR created automatically by Jules for task [1882118618611378194](https://jules.google.com/task/1882118618611378194) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling by replacing detailed internal exception messages with clear, generic error messages.
  * Added logging for job synchronization failures while keeping sensitive technical details out of responses.
  * Updated chat, approval, and transcription errors to provide safer, user-friendly feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->