### PR TITLE
⚡ Bolt: Optimize export_cover_letter.py Supabase queries

### DIFF
--- a/backend/routers/cover_letter.py
+++ b/backend/routers/cover_letter.py
@@ -1,5 +1,6 @@
 import uuid
 import datetime
+import asyncio
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from dependencies import get_current_user, get_supabase_admin
@@ -19,8 +20,8 @@ async def generate_cover_letter(
     # Fetch resume text
     actual_resume_id = payload.resume_id
     if payload.resume_id == "default":
-        r = (
-            db.table("resumes")
+        r = await asyncio.to_thread(
+            lambda: db.table("resumes")
             .select("id, raw_text")
             .eq("user_id", user["user_id"])
             .order("created_at", desc=True)
@@ -28,12 +29,12 @@ async def generate_cover_letter(
             .execute()
         )
         if not r.data:
-             raise HTTPException(status_code=404, detail="No resumes found for this user.")
+            raise HTTPException(status_code=404, detail="No resumes found for this user.")
         resume_text = r.data[0]["raw_text"]
         actual_resume_id = r.data[0]["id"]
     else:
-        r = (
-            db.table("resumes")
+        r = await asyncio.to_thread(
+            lambda: db.table("resumes")
             .select("raw_text")
             .eq("id", payload.resume_id)
             .eq("user_id", user["user_id"])
@@ -69,14 +70,16 @@ async def generate_cover_letter(
     
     # Save to database
     letter_id = str(uuid.uuid4())
-    db.table("cover_letters").insert({
-        "id": letter_id,
-        "user_id": user["user_id"],
-        "resume_id": actual_resume_id,
-        "target_role": payload.target_role or "Unknown",
-        "content": content,
-        "tone": payload.tone
-    }).execute()
+    await asyncio.to_thread(
+        lambda: db.table("cover_letters").insert({
+            "id": letter_id,
+            "user_id": user["user_id"],
+            "resume_id": actual_resume_id,
+            "target_role": payload.target_role or "Unknown",
+            "content": content,
+            "tone": payload.tone
+        }).execute()
+    )
 
     return CoverLetterResponse(
         id=letter_id,
@@ -93,31 +96,20 @@ async def export_cover_letter(
     db=Depends(get_supabase_admin),
 ):
     """Exports a cover letter as PDF or Docx."""
-    r = (
-        db.table("cover_letters")
-        .select("*")
-        .eq("id", letter_id)
-        .eq("user_id", user["user_id"])
-        .single()
-        .execute()
-    )
+    # What: Wraps synchronous Supabase client calls in asyncio.to_thread
+    # Why: The Supabase python client is synchronous; calling .execute() directly blocks the async event loop and increases latency.
+    r = await asyncio.to_thread(lambda: db.table("cover_letters").select("*").eq("id", letter_id).eq("user_id", user["user_id"]).single().execute())
     if not r.data:
         raise HTTPException(status_code=404, detail="Cover letter not found.")
 
     # Fetch user profile for headers
-    p = (
-        db.table("profiles")
-        .select("full_name")
-        .eq("id", user["user_id"])
-        .single()
-        .execute()
-    )
+    p = await asyncio.to_thread(lambda: db.table("profiles").select("full_name").eq("id", user["user_id"]).single().execute())
     
     header_info = {
         "name": p.data.get("full_name", "Valued User"),
         "email": user.get("email", ""),
         "date": datetime.date.today().strftime("%B %d, %Y"),
-        "location": "Global", # Can be updated if profile has location
+        "location": "Global",  # Can be updated if profile has location
         "phone": ""
     }
 


### PR DESCRIPTION
### 💡 What
Refactored Supabase queries in `backend/routers/cover_letter.py` to wrap synchronous `.execute()` calls in `asyncio.to_thread`. This applies to both `export_cover_letter` and `generate_cover_letter` routes.

### 🎯 Why
The Supabase Python client is synchronous. Calling `.execute()` consecutively in an `async def` FastAPI route blocks the async event loop and incurs cumulative round-trip latency. Wrapping these queries in `asyncio.to_thread` unblocks the main thread while preserving the logical short-circuit logic where applicable.

### 📊 Impact
Reduces the endpoint execution time by unblocking the main thread, decreasing latency and improving throughput of the ASGI server by not blocking the main event loop.

### 🔬 Measurement
Measure endpoint response times before and after this change under load; monitor FastAPI async worker thread saturation.

---
*PR created automatically by Jules for task [4629295956421175412](https://jules.google.com/task/4629295956421175412) started by @SudoAnirudh*