### PR TITLE
⚡ Bolt: Optimize export_cover_letter queries

### DIFF
--- a/backend/routers/cover_letter.py
+++ b/backend/routers/cover_letter.py
@@ -1,5 +1,6 @@
 import uuid
 import datetime
+import asyncio
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 from dependencies import get_current_user, get_supabase_admin
@@ -93,26 +94,15 @@ async def export_cover_letter(
     db=Depends(get_supabase_admin),
 ):
     """Exports a cover letter as PDF or Docx."""
-    r = (
-        db.table("cover_letters")
-        .select("*")
-        .eq("id", letter_id)
-        .eq("user_id", user["user_id"])
-        .single()
-        .execute()
-    )
+    # Why: The Supabase python client is synchronous; executing these queries blocks the async event loop.
+    r = await asyncio.to_thread(lambda: db.table("cover_letters").select("*").eq("id", letter_id).eq("user_id", user["user_id"]).single().execute())
+
     if not r.data:
         raise HTTPException(status_code=404, detail="Cover letter not found.")
 
     # Fetch user profile for headers
-    p = (
-        db.table("profiles")
-        .select("full_name")
-        .eq("id", user["user_id"])
-        .single()
-        .execute()
-    )
-    
+    p = await asyncio.to_thread(lambda: db.table("profiles").select("full_name").eq("id", user["user_id"]).single().execute())
+
     header_info = {
         "name": p.data.get("full_name", "Valued User"),
         "email": user.get("email", ""),


### PR DESCRIPTION
💡 What: Wrapped synchronous Supabase queries in `asyncio.to_thread` and executed them sequentially in the `export_cover_letter` endpoint.
🎯 Why: The Supabase python client is synchronous. Direct `.execute()` calls block the main thread and event loop. Sequential `asyncio.to_thread` allows the event loop to continue serving other requests while preserving the conditional fallback.
📊 Impact: Reduces event loop blocking, improving concurrent request handling.
🔬 Measurement: Compare API throughput and latency under load for exporting a cover letter before and after the change.

---
*PR created automatically by Jules for task [1395218541901757719](https://jules.google.com/task/1395218541901757719) started by @SudoAnirudh*