### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent information disclosure in error responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** OS-level file operations (like `os.remove`) during cleanup were only catching `FileNotFoundError`. Other exceptions could propagate and leak internal paths or stack traces in 500 responses.
 **Learning:** System operations can fail for many reasons (e.g., permissions, locks). Unhandled exceptions in cleanup routines break the "fail securely" principle and risk information disclosure.
 **Prevention:** Always catch broad exceptions like `Exception` in cleanup/teardown routines, log them securely, and prevent them from propagating to the client.
+## 2025-01-09 - Information Disclosure via Exception Propagation
+**Vulnerability:** The exception `str(e)` was directly passed to `HTTPException(detail=str(e))` in FastAPI routes, which can leak stack traces or internal implementation details (e.g., from DB timeouts, missing secrets) to end users.
+**Learning:** Returning raw stringified exceptions in production APIs exposes the internal state and breaks the "fail securely" principle.
+**Prevention:** Never pass `str(e)` to `HTTPException`. Always log the full exception internally via `logger.error` and return a generic, sanitized error message to the client.

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -390,7 +390,7 @@ async def transcribe(
         return {"text": text}
     except Exception as e:
         logger.error(f"Transcription route failure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Audio transcription failed.")
 
 
 @router.post("/next-question", response_model=InterviewQuestion)

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -78,4 +78,5 @@ async def trigger_jobs_sync(
         new_jobs = await sync_twitter_jobs()
         return {"status": "success", "message": f"Sync complete. Added {new_jobs} jobs."}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Jobs sync failed: {e}")
+        raise HTTPException(status_code=500, detail="Failed to sync jobs.")


### PR DESCRIPTION
🚨 **Severity:** MEDIUM

💡 **Vulnerability:**
Passing raw exception details (`str(e)`) directly to the client via `HTTPException(detail=str(e))` inside API routes. This breaks the "fail securely" principle and risks leaking internal application states, database connection errors, stack traces, or internal server paths.

🎯 **Impact:**
Malicious users or automated scanners could trigger specific edge cases to observe unhandled exceptions, potentially gaining insights into internal dependencies or system configurations.

🔧 **Fix:**
Modified `backend/routers/jobs_board.py` and `backend/routers/interview.py` to:
1. Log the full exception internally via `logger.error`.
2. Return a generic, sanitized string (e.g., `"Failed to sync jobs."`) to the client rather than the raw `str(e)`.
3. Created a new entry in `.jules/sentinel.md` documenting the anti-pattern of exception leakage in FastAPI apps.

✅ **Verification:**
Executed backend linting (`flake8`) and unit tests (`pytest`). Verified that the routes will now safely swallow exception specifics and bubble up 500 error codes safely.

---
*PR created automatically by Jules for task [4155992624600598816](https://jules.google.com/task/4155992624600598816) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for audio transcription and job synchronization failures.
  * Users now see clear, generic error messages instead of potentially sensitive technical details when these operations fail.

* **Security**
  * Strengthened protection against exposing internal exception information in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->