### PR TITLE
🎨 Palette: Add ARIA labels to InterviewPanel buttons

### DIFF
--- a/frontend/components/InterviewPanel.tsx
+++ b/frontend/components/InterviewPanel.tsx
@@ -809,6 +809,7 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
                 : "bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
             } disabled:opacity-50`}
             title={isListening ? "Mute Microphone" : "Unmute Microphone"}
+            aria-label={isListening ? "Mute Microphone" : "Unmute Microphone"}
           >
             {isListening ? <Mic size={18} /> : <MicOff size={18} />}
           </button>
@@ -824,6 +825,7 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
                 : "bg-red-500 hover:bg-red-600 text-white shadow-lg shadow-red-500/20"
             }`}
             title={cameraOn ? "Stop Video" : "Start Video"}
+            aria-label={cameraOn ? "Stop Video" : "Start Video"}
           >
             {cameraOn ? <Video size={18} /> : <VideoOff size={18} />}
           </button>
@@ -856,6 +858,7 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
               onClick={onExit}
               className="p-3.5 rounded-full bg-slate-800 hover:bg-slate-700 text-red-400 border border-slate-700 transition-all active:scale-90"
               title="Hang Up / Exit Interview"
+              aria-label="Hang Up / Exit Interview"
             >
               <PhoneOff size={18} />
             </button>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the icon-only microphone, camera, and exit buttons in the InterviewPanel component.
🎯 Why: To improve keyboard and screen reader accessibility for interactive media controls in the interview panel.
📸 Before/After: Visuals remain unchanged, screen reader experience improved.
♿ Accessibility: Added descriptive `aria-label`s to the `button` elements that currently only rely on visual icons and a tooltip (`title` attribute) which can be insufficient or unreliable for some screen readers.

---
*PR created automatically by Jules for task [1182055081809226634](https://jules.google.com/task/1182055081809226634) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added descriptive labels to the microphone, camera, and exit interview controls for improved screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->