### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent Error Details Exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** OS-level file operations (like `os.remove`) during cleanup were only catching `FileNotFoundError`. Other exceptions could propagate and leak internal paths or stack traces in 500 responses.
 **Learning:** System operations can fail for many reasons (e.g., permissions, locks). Unhandled exceptions in cleanup routines break the "fail securely" principle and risk information disclosure.
 **Prevention:** Always catch broad exceptions like `Exception` in cleanup/teardown routines, log them securely, and prevent them from propagating to the client.
+## 2024-06-03 - Prevent Error Details Exposure
+**Vulnerability:** Fast API `detail=str(e)` exposed raw error strings and potential system paths in HTTP 500 response bodies.
+**Learning:** Default exception handling in FastAPI can leak sensitive application state if raw exception strings are passed to the client.
+**Prevention:** Always log the complete exception locally using `logger.error` and return a generic, sanitized HTTP error message to the client.

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -390,7 +390,7 @@ async def transcribe(
         return {"text": text}
     except Exception as e:
         logger.error(f"Transcription route failure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="An error occurred during transcription.")
 
 
 @router.post("/next-question", response_model=InterviewQuestion)

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -78,4 +78,5 @@ async def trigger_jobs_sync(
         new_jobs = await sync_twitter_jobs()
         return {"status": "success", "message": f"Sync complete. Added {new_jobs} jobs."}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Error during job sync: {e}")
+        raise HTTPException(status_code=500, detail="An error occurred during job synchronization.")


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Raw exception strings were being passed to FastAPI HTTPExceptions, potentially leaking system details and sensitive application state in HTTP 500 responses.
🎯 Impact: Malicious users could intentionally trigger errors to gather system information, path configurations, or database structure hints.
🔧 Fix: Replaced `detail=str(e)` with sanitized, generic error messages while ensuring the raw errors are preserved in the backend server logs.
✅ Verification: Verified locally by triggering an error and confirming the client receives a generic message while the backend log captures the full exception.

---
*PR created automatically by Jules for task [5217908722802199957](https://jules.google.com/task/5217908722802199957) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for transcription and job synchronization failures.
  * Users now see a generic error message instead of internal exception details or system paths.
  * Failure details continue to be logged securely for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->