### PR TITLE
🎨 Palette: Improve accessibility of multimedia controls in Interview Studio

### DIFF
--- a/frontend/components/InterviewPanel.tsx
+++ b/frontend/components/InterviewPanel.tsx
@@ -633,7 +633,8 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
               <button
                 type="button"
                 onClick={() => void requestFullscreen()}
-                className="px-10 py-4 rounded-[24px] bg-brand-blue hover:bg-blue-600 text-white font-display font-black shadow-2xl active:scale-[0.98] transition-all"
+                className="px-10 py-4 rounded-[24px] bg-brand-blue hover:bg-blue-600 text-white font-display font-black shadow-2xl active:scale-[0.98] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2"
+                aria-label="Restore Fullscreen"
               >
                 Restore Fullscreen
               </button>
@@ -803,12 +804,13 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
             type="button"
             onClick={toggleListening}
             disabled={!speechSupported || submitting || transcribing}
-            className={`p-3.5 rounded-full transition-all active:scale-90 ${
+            className={`p-3.5 rounded-full transition-all active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 ${
               isListening
                 ? "bg-red-500 hover:bg-red-600 text-white shadow-lg shadow-red-500/20"
                 : "bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
             } disabled:opacity-50`}
             title={isListening ? "Mute Microphone" : "Unmute Microphone"}
+            aria-label={isListening ? "Mute Microphone" : "Unmute Microphone"}
           >
             {isListening ? <Mic size={18} /> : <MicOff size={18} />}
           </button>
@@ -818,12 +820,13 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
             type="button"
             onClick={() => setCameraOn(!cameraOn)}
             disabled={submitting || transcribing}
-            className={`p-3.5 rounded-full transition-all active:scale-90 ${
+            className={`p-3.5 rounded-full transition-all active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 ${
               cameraOn
                 ? "bg-slate-800 hover:bg-slate-700 text-slate-300 border border-slate-700"
                 : "bg-red-500 hover:bg-red-600 text-white shadow-lg shadow-red-500/20"
             }`}
             title={cameraOn ? "Stop Video" : "Start Video"}
+            aria-label={cameraOn ? "Stop Video" : "Start Video"}
           >
             {cameraOn ? <Video size={18} /> : <VideoOff size={18} />}
           </button>
@@ -854,8 +857,9 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
             <button
               type="button"
               onClick={onExit}
-              className="p-3.5 rounded-full bg-slate-800 hover:bg-slate-700 text-red-400 border border-slate-700 transition-all active:scale-90"
+              className="p-3.5 rounded-full bg-slate-800 hover:bg-slate-700 text-red-400 border border-slate-700 transition-all active:scale-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2"
               title="Hang Up / Exit Interview"
+              aria-label="Hang Up or Exit Interview"
             >
               <PhoneOff size={18} />
             </button>
@@ -866,7 +870,8 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
               type="button"
               onClick={() => handleNext(false)}
               disabled={submitting || transcribing}
-              className="flex items-center gap-2 px-6 py-3 rounded-2xl bg-brand-blue hover:bg-blue-600 text-white font-bold text-xs uppercase tracking-wider shadow-lg active:scale-95 transition-all"
+              className="flex items-center gap-2 px-6 py-3 rounded-2xl bg-brand-blue hover:bg-blue-600 text-white font-bold text-xs uppercase tracking-wider shadow-lg active:scale-95 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2"
+              aria-label="Next Question"
             >
               <span>Next</span>
               <ChevronRight size={14} />
@@ -876,7 +881,8 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
               type="button"
               onClick={() => void handleFinish()}
               disabled={submitting || transcribing}
-              className="flex items-center gap-2 px-6 py-3 rounded-2xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold text-xs uppercase tracking-wider shadow-lg active:scale-95 transition-all"
+              className="flex items-center gap-2 px-6 py-3 rounded-2xl bg-emerald-600 hover:bg-emerald-700 text-white font-bold text-xs uppercase tracking-wider shadow-lg active:scale-95 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2"
+              aria-label="Submit Interview"
             >
               <span>{submitting ? "Submitting..." : "Submit Call"}</span>
             </button>
@@ -900,7 +906,8 @@ export default function InterviewPanel({ session, onComplete, onExit }: Props) {
 
         <textarea
           id={`answer-${q.question_id}`}
-          className="w-full bg-white/60 border border-slate-200 rounded-2xl p-5 text-slate-800 text-base leading-relaxed resize-none min-h-[140px] focus:outline-none focus:border-brand-blue/50 font-body placeholder:text-slate-400"
+          aria-label="Interview answer response"
+          className="w-full bg-white/60 border border-slate-200 rounded-2xl p-5 text-slate-800 text-base leading-relaxed resize-none min-h-[140px] focus:outline-none focus:border-brand-blue/50 font-body placeholder:text-slate-400 focus-visible:ring-2 focus-visible:ring-brand-blue"
           placeholder={
             transcribing
               ? "Refining transcription with high-accuracy AI..."


### PR DESCRIPTION
## 💡 What
- Added explicit dynamic `aria-label`s to the Mic and Video toggle buttons in the Interview Studio.
- Restored keyboard accessibility by enforcing uniform `focus-visible` ring indicators across all action controls (Next, Hang Up, Submit, Restore Fullscreen).
- Associated the main transcription `<textarea>` with a descriptive `aria-label`.
- Logged new UX accessibility learnings regarding dynamic ARIA states and keyboard focus indicators to Palette's journal.

## 🎯 Why
- Ensures screen reader users can accurately interpret the state and purpose of critical session controls (like knowing whether they are about to "Mute" or "Unmute").
- Allows keyboard-only users to seamlessly navigate the interview interface without losing focus context.

## 📸 Before/After
- Before: Toggles lacked dynamic aria states; custom buttons had no visible keyboard focus rings.
- After: Buttons clearly announce their actionable states and exhibit consistent blue/red/emerald focus rings when tabbed.

## ♿ Accessibility
- Enhanced semantic structure (WCAG 4.1.2 Name, Role, Value).
- Restored focus indicators (WCAG 2.4.7 Focus Visible).

---
*PR created automatically by Jules for task [3983315558520523731](https://jules.google.com/task/3983315558520523731) started by @SudoAnirudh*