### PR TITLE
⚡ Bolt: Optimize applications.py with asyncio.to_thread

### DIFF
--- a/backend/routers/applications.py
+++ b/backend/routers/applications.py
@@ -1,3 +1,4 @@
+import asyncio
 import uuid
 from fastapi import APIRouter, Depends
 from dependencies import get_current_user, get_supabase_admin
@@ -27,11 +28,11 @@ async def create_application(
 ):
     """Adds a new job application record for tracking."""
     app_id = str(uuid.uuid4())
-    db.table("job_applications").insert({
+    await asyncio.to_thread(lambda: db.table("job_applications").insert({
         "id": app_id,
         "user_id": user["user_id"],
         **payload.model_dump()
-    }).execute()
+    }).execute())
     return {"message": "Application tracked successfully.", "id": app_id}
 
 @router.get("/", response_model=List[dict])
@@ -40,13 +41,13 @@ async def list_applications(
     db=Depends(get_supabase_admin),
 ):
     """Lists all tracked applications for the current user."""
-    r = (
+    r = await asyncio.to_thread(lambda: (
         db.table("job_applications")
         .select("*")
         .eq("user_id", user["user_id"])
         .order("created_at", desc=True)
         .execute()
-    )
+    ))
     return r.data
 
 @router.patch("/{app_id}")
@@ -57,9 +58,9 @@ async def update_application(
     db=Depends(get_supabase_admin),
 ):
     """Updates status or notes for an application."""
-    db.table("job_applications").update(
+    await asyncio.to_thread(lambda: db.table("job_applications").update(
         payload.model_dump(exclude_none=True)
-    ).eq("id", app_id).eq("user_id", user["user_id"]).execute()
+    ).eq("id", app_id).eq("user_id", user["user_id"]).execute())
     return {"message": "Application updated."}
 
 @router.delete("/{app_id}")
@@ -69,5 +70,5 @@ async def delete_application(
     db=Depends(get_supabase_admin),
 ):
     """Removes an application record."""
-    db.table("job_applications").delete().eq("id", app_id).eq("user_id", user["user_id"]).execute()
+    await asyncio.to_thread(lambda: db.table("job_applications").delete().eq("id", app_id).eq("user_id", user["user_id"]).execute())
     return {"message": "Application removed."}

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,11 @@
+💡 What
+Offloaded synchronous Supabase `.execute()` database queries to a background thread using `asyncio.to_thread(lambda: ...)` in `applications.py`.
+
+🎯 Why
+Because `supabase-py` executes its `.execute()` calls synchronously, keeping them directly inside FastAPI `async def` endpoints blocks the main event loop. This significantly degraded concurrent performance and response times under load.
+
+📊 Impact
+Prevents event loop blocking, which allows FastAPI to serve other requests concurrently while waiting for the database response. Reduces latency bottlenecks in the applications router endpoints.
+
+🔬 Measurement
+Load test the endpoints with multiple concurrent requests to observe an improvement in overall server throughput, or check CPU thread utilization ensuring the main async loop is not blocked during Supabase DB operations.


### PR DESCRIPTION
💡 What
Offloaded synchronous Supabase `.execute()` database queries to a background thread using `asyncio.to_thread(lambda: ...)` in `applications.py`. 

🎯 Why
Because `supabase-py` executes its `.execute()` calls synchronously, keeping them directly inside FastAPI `async def` endpoints blocks the main event loop. This significantly degraded concurrent performance and response times under load.

📊 Impact
Prevents event loop blocking, which allows FastAPI to serve other requests concurrently while waiting for the database response. Reduces latency bottlenecks in the applications router endpoints.

🔬 Measurement
Load test the endpoints with multiple concurrent requests to observe an improvement in overall server throughput, or check CPU thread utilization ensuring the main async loop is not blocked during Supabase DB operations.

---
*PR created automatically by Jules for task [8144645923163047318](https://jules.google.com/task/8144645923163047318) started by @SudoAnirudh*