### PR TITLE
⚡ Bolt: [Offload synchronous database calls in applications endpoints]

### DIFF
--- a/backend/routers/applications.py
+++ b/backend/routers/applications.py
@@ -1,4 +1,5 @@
 import uuid
+import asyncio
 from fastapi import APIRouter, Depends
 from dependencies import get_current_user, get_supabase_admin
 from pydantic import BaseModel
@@ -27,11 +28,11 @@ async def create_application(
 ):
     """Adds a new job application record for tracking."""
     app_id = str(uuid.uuid4())
-    db.table("job_applications").insert({
+    await asyncio.to_thread(lambda: db.table("job_applications").insert({
         "id": app_id,
         "user_id": user["user_id"],
         **payload.model_dump()
-    }).execute()
+    }).execute())
     return {"message": "Application tracked successfully.", "id": app_id}
 
 @router.get("/", response_model=List[dict])
@@ -40,13 +41,13 @@ async def list_applications(
     db=Depends(get_supabase_admin),
 ):
     """Lists all tracked applications for the current user."""
-    r = (
+    r = await asyncio.to_thread(lambda: (
         db.table("job_applications")
         .select("*")
         .eq("user_id", user["user_id"])
         .order("created_at", desc=True)
         .execute()
-    )
+    ))
     return r.data
 
 @router.patch("/{app_id}")
@@ -57,9 +58,9 @@ async def update_application(
     db=Depends(get_supabase_admin),
 ):
     """Updates status or notes for an application."""
-    db.table("job_applications").update(
+    await asyncio.to_thread(lambda: db.table("job_applications").update(
         payload.model_dump(exclude_none=True)
-    ).eq("id", app_id).eq("user_id", user["user_id"]).execute()
+    ).eq("id", app_id).eq("user_id", user["user_id"]).execute())
     return {"message": "Application updated."}
 
 @router.delete("/{app_id}")
@@ -69,5 +70,5 @@ async def delete_application(
     db=Depends(get_supabase_admin),
 ):
     """Removes an application record."""
-    db.table("job_applications").delete().eq("id", app_id).eq("user_id", user["user_id"]).execute()
+    await asyncio.to_thread(lambda: db.table("job_applications").delete().eq("id", app_id).eq("user_id", user["user_id"]).execute())
     return {"message": "Application removed."}


### PR DESCRIPTION
💡 What: Added `asyncio.to_thread` wrappers around synchronous Supabase `.execute()` calls in `backend/routers/applications.py` endpoints (`create_application`, `list_applications`, `update_application`, `delete_application`).
🎯 Why: FastAPI `async def` endpoints run on the main event loop. Making synchronous database calls directly inside them blocks the loop, causing a performance bottleneck when handling multiple concurrent requests.
📊 Impact: Prevents event loop blocking, significantly improving concurrent request handling capacity and overall endpoint responsiveness.
🔬 Measurement: Load test the endpoints with multiple concurrent requests to observe reduced latency and stable event loop behavior compared to the unoptimized version.

---
*PR created automatically by Jules for task [11596134903274463009](https://jules.google.com/task/11596134903274463009) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness for application creation, listing, updating, and deletion operations.
  * Reduced the risk of database activity blocking other requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->