### PR TITLE
⚡ Bolt: Offload synchronous Supabase calls to background thread

### DIFF
--- a/backend/routers/applications.py
+++ b/backend/routers/applications.py
@@ -1,4 +1,5 @@
 import uuid
+import asyncio
 from fastapi import APIRouter, Depends
 from dependencies import get_current_user, get_supabase_admin
 from pydantic import BaseModel
@@ -27,11 +28,12 @@ async def create_application(
 ):
     """Adds a new job application record for tracking."""
     app_id = str(uuid.uuid4())
-    db.table("job_applications").insert({
+    # What: Offloaded synchronous Supabase insert to a background thread to prevent event loop blocking.
+    await asyncio.to_thread(lambda: db.table("job_applications").insert({
         "id": app_id,
         "user_id": user["user_id"],
         **payload.model_dump()
-    }).execute()
+    }).execute())
     return {"message": "Application tracked successfully.", "id": app_id}
 
 @router.get("/", response_model=List[dict])
@@ -40,13 +42,14 @@ async def list_applications(
     db=Depends(get_supabase_admin),
 ):
     """Lists all tracked applications for the current user."""
-    r = (
+    # What: Offloaded synchronous Supabase select to a background thread to prevent event loop blocking.
+    r = await asyncio.to_thread(lambda: (
         db.table("job_applications")
         .select("*")
         .eq("user_id", user["user_id"])
         .order("created_at", desc=True)
         .execute()
-    )
+    ))
     return r.data
 
 @router.patch("/{app_id}")
@@ -57,9 +60,10 @@ async def update_application(
     db=Depends(get_supabase_admin),
 ):
     """Updates status or notes for an application."""
-    db.table("job_applications").update(
+    # What: Offloaded synchronous Supabase update to a background thread to prevent event loop blocking.
+    await asyncio.to_thread(lambda: db.table("job_applications").update(
         payload.model_dump(exclude_none=True)
-    ).eq("id", app_id).eq("user_id", user["user_id"]).execute()
+    ).eq("id", app_id).eq("user_id", user["user_id"]).execute())
     return {"message": "Application updated."}
 
 @router.delete("/{app_id}")
@@ -69,5 +73,6 @@ async def delete_application(
     db=Depends(get_supabase_admin),
 ):
     """Removes an application record."""
-    db.table("job_applications").delete().eq("id", app_id).eq("user_id", user["user_id"]).execute()
+    # What: Offloaded synchronous Supabase delete to a background thread to prevent event loop blocking.
+    await asyncio.to_thread(lambda: db.table("job_applications").delete().eq("id", app_id).eq("user_id", user["user_id"]).execute())
     return {"message": "Application removed."}


### PR DESCRIPTION
💡 What: Wrapped synchronous Supabase `.execute()` calls in `asyncio.to_thread` for `backend/routers/applications.py`.
🎯 Why: The Supabase python client is synchronous. Calling it directly in `async def` endpoints blocks the async event loop, heavily increasing latency when multiple requests hit the server concurrently.
📊 Impact: Eliminates event loop blocking for the applications router, significantly improving concurrent throughput and reducing response times under load.
🔬 Measurement: Verified functionality via backend test suite. Benchmarking the API endpoints with a concurrency tool like `wrk` or `locust` will show higher RPS and lower p99 latency compared to the synchronous approach.

---
*PR created automatically by Jules for task [10353501690760283690](https://jules.google.com/task/10353501690760283690) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved application data operations to remain responsive during database inserts, reads, updates, and deletions.
  * Reduced the risk of delays affecting other concurrent app activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->