### PR TITLE
🎨 Palette: Add focus visible styles for resume dropzone

### DIFF
--- a/frontend/app/dashboard/roadmap/page.tsx
+++ b/frontend/app/dashboard/roadmap/page.tsx
@@ -130,7 +130,7 @@ export default function RoadmapPage() {
 
     // Flatten all completed skills for the backend
     const getCompletedNames = (skills: RoadmapSkill[]): string[] => {
-      let names: string[] = [];
+      const names: string[] = [];
       skills.forEach((s) => {
         if (s.status === "completed") names.push(s.name);
         if (s.children) names.push(...getCompletedNames(s.children));

--- a/frontend/components/ResumeUploader.tsx
+++ b/frontend/components/ResumeUploader.tsx
@@ -78,7 +78,7 @@ export default function ResumeUploader({ onResult }: Props) {
     <div
       {...getRootProps()}
       id="resume-dropzone"
-      className={`glass-card p-12 flex flex-col items-center justify-center gap-6 cursor-pointer transition-all border-dashed rounded-[32px] bg-white/40 border-white/60 shadow-glass backdrop-blur-xl group ${
+      className={`glass-card p-12 flex flex-col items-center justify-center gap-6 cursor-pointer transition-all border-dashed rounded-[32px] bg-white/40 border-white/60 shadow-glass backdrop-blur-xl group focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#7C9ADD]/50 ${
         isDragActive
           ? "bg-[#7C9ADD]/5 border-[#7C9ADD] scale-[0.99] shadow-inner"
           : " #7C9ADD]/40"

--- a/pr_details.md
+++ b/pr_details.md
@@ -1,0 +1,11 @@
+## 💡 What
+Added `focus-visible` styles (`focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#7C9ADD]/50`) to the ResumeUploader dropzone component.
+
+## 🎯 Why
+The drag-and-drop zone acts as an interactive element (file input) and can be focused via keyboard navigation. Previously, it lacked a clear visual indicator when focused via keyboard, making it difficult for keyboard users to know where their focus was.
+
+## 📸 Before/After
+No screenshots (visual change only when navigating via keyboard).
+
+## ♿ Accessibility
+Improves keyboard navigation and accessibility by providing a clear focus ring, adhering to WCAG focus visibility guidelines.


### PR DESCRIPTION
## 💡 What
Added `focus-visible` styles (`focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-[#7C9ADD]/50`) to the ResumeUploader dropzone component.

## 🎯 Why
The drag-and-drop zone acts as an interactive element (file input) and can be focused via keyboard navigation. Previously, it lacked a clear visual indicator when focused via keyboard, making it difficult for keyboard users to know where their focus was.

## 📸 Before/After
No screenshots (visual change only when navigating via keyboard).

## ♿ Accessibility
Improves keyboard navigation and accessibility by providing a clear focus ring, adhering to WCAG focus visibility guidelines.

---
*PR created automatically by Jules for task [8217344234037122724](https://jules.google.com/task/8217344234037122724) started by @SudoAnirudh*