### PR TITLE
🎨 Palette: Improve accessibility for dashboard navigation and mobile menu

### DIFF
--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -176,6 +176,7 @@ export default function DashboardLayout({
               >
                 <Link
                   href={href}
+                  aria-current={pathname === href ? "page" : undefined}
                   className={`relative flex items-center gap-3 px-4 py-3 rounded-2xl transition-all duration-300 group ${
                     pathname === href
                       ? "bg-indigo-500 text-white shadow-lg shadow-indigo-500/25"
@@ -243,6 +244,7 @@ export default function DashboardLayout({
               <Link
                 key={href}
                 href={href}
+                aria-current={isActive ? "page" : undefined}
                 onClick={() => setIsMobileMenuOpen(false)}
                 className={`relative flex-1 flex flex-col items-center justify-center py-2.5 px-1 rounded-2xl transition-all duration-300 ${
                   isActive ? "text-indigo-500" : "text-muted-foreground"
@@ -270,6 +272,9 @@ export default function DashboardLayout({
           {/* Menu Button */}
           <button
             onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+            aria-expanded={isMobileMenuOpen}
+            aria-controls="mobile-menu-content"
+            aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
             className={`relative flex-1 flex flex-col items-center justify-center py-2.5 px-1 rounded-2xl transition-all duration-300 ${
               isMobileMenuOpen
                 ? "text-indigo-500 bg-indigo-500/10"
@@ -292,6 +297,7 @@ export default function DashboardLayout({
       <AnimatePresence>
         {isMobileMenuOpen && (
           <motion.div
+            id="mobile-menu-content"
             initial={{ opacity: 0, y: "100%" }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: "100%" }}

--- a/frontend/app/dashboard/roadmap/page.tsx
+++ b/frontend/app/dashboard/roadmap/page.tsx
@@ -130,7 +130,7 @@ export default function RoadmapPage() {
 
     // Flatten all completed skills for the backend
     const getCompletedNames = (skills: RoadmapSkill[]): string[] => {
-      let names: string[] = [];
+      const names: string[] = [];
       skills.forEach((s) => {
         if (s.status === "completed") names.push(s.name);
         if (s.children) names.push(...getCompletedNames(s.children));


### PR DESCRIPTION
### 💡 What
Added `aria-current="page"` attribute to the main dashboard sidebar navigation links and mobile bottom navigation links to correctly inform screen readers of the active page. Additionally, added proper ARIA attributes (`aria-expanded`, `aria-controls`, and `aria-label`) to the mobile bottom bar menu toggle button, and added the corresponding `id` to the mobile slide-up menu container.

### 🎯 Why
Screen reader users need context as to which navigational link corresponds to the currently viewed page. Next.js custom `Link` elements do not handle this automatically. By adding `aria-current="page"`, visually active states (highlighted links) are made perceivable programmatically. The mobile navigation menu toggle button lacked context for screen readers regarding its state (expanded/collapsed) and purpose, leading to poor usability for ATs on mobile devices.

### 📸 Before/After
*No visual changes. Accessibility improvements only.*

### ♿ Accessibility
- Sidebar navigation links now express the active state to ATs.
- Mobile bottom navigation links now express the active state to ATs.
- Mobile menu toggle button provides semantic expanded/collapsed states and associates with its target menu content for screen readers.

---
*PR created automatically by Jules for task [17269985243007793582](https://jules.google.com/task/17269985243007793582) started by @SudoAnirudh*