### PR TITLE
⚡ Bolt: [performance improvement] Offload synchronous Supabase queries in applications router

### DIFF
--- a/backend/routers/applications.py
+++ b/backend/routers/applications.py
@@ -1,4 +1,5 @@
 import uuid
+import asyncio
 from fastapi import APIRouter, Depends
 from dependencies import get_current_user, get_supabase_admin
 from pydantic import BaseModel
@@ -27,11 +28,14 @@ async def create_application(
 ):
     """Adds a new job application record for tracking."""
     app_id = str(uuid.uuid4())
-    db.table("job_applications").insert({
+
+    # Bolt: Offload synchronous Supabase query to prevent event loop blocking
+    await asyncio.to_thread(lambda: db.table("job_applications").insert({
         "id": app_id,
         "user_id": user["user_id"],
         **payload.model_dump()
-    }).execute()
+    }).execute())
+
     return {"message": "Application tracked successfully.", "id": app_id}
 
 @router.get("/", response_model=List[dict])
@@ -40,13 +44,14 @@ async def list_applications(
     db=Depends(get_supabase_admin),
 ):
     """Lists all tracked applications for the current user."""
-    r = (
+    # Bolt: Offload synchronous Supabase query to prevent event loop blocking
+    r = await asyncio.to_thread(lambda: (
         db.table("job_applications")
         .select("*")
         .eq("user_id", user["user_id"])
         .order("created_at", desc=True)
         .execute()
-    )
+    ))
     return r.data
 
 @router.patch("/{app_id}")
@@ -57,9 +62,10 @@ async def update_application(
     db=Depends(get_supabase_admin),
 ):
     """Updates status or notes for an application."""
-    db.table("job_applications").update(
+    # Bolt: Offload synchronous Supabase query to prevent event loop blocking
+    await asyncio.to_thread(lambda: db.table("job_applications").update(
         payload.model_dump(exclude_none=True)
-    ).eq("id", app_id).eq("user_id", user["user_id"]).execute()
+    ).eq("id", app_id).eq("user_id", user["user_id"]).execute())
     return {"message": "Application updated."}
 
 @router.delete("/{app_id}")
@@ -69,5 +75,6 @@ async def delete_application(
     db=Depends(get_supabase_admin),
 ):
     """Removes an application record."""
-    db.table("job_applications").delete().eq("id", app_id).eq("user_id", user["user_id"]).execute()
+    # Bolt: Offload synchronous Supabase query to prevent event loop blocking
+    await asyncio.to_thread(lambda: db.table("job_applications").delete().eq("id", app_id).eq("user_id", user["user_id"]).execute())
     return {"message": "Application removed."}


### PR DESCRIPTION
💡 What: Wrapped all synchronous Supabase `.execute()` calls in `backend/routers/applications.py` with `await asyncio.to_thread(lambda: ...)`.
🎯 Why: The supabase-py client uses synchronous HTTP requests. Calling these inside FastAPI's `async def` endpoints blocked the main event loop, severely limiting concurrency and overall application performance.
📊 Impact: Prevents event loop blocking during database operations, significantly increasing the application's ability to handle concurrent requests under load.
🔬 Measurement: Verify by load testing the applications endpoints concurrently; the event loop should remain responsive, and median response times for concurrent requests should drop significantly.

---
*PR created automatically by Jules for task [999124196271649394](https://jules.google.com/task/999124196271649394) started by @SudoAnirudh*