### PR TITLE
⚡ Bolt: [performance improvement] Offload synchronous Supabase calls to thread

### DIFF
--- a/backend/routers/applications.py
+++ b/backend/routers/applications.py
@@ -1,3 +1,4 @@
+import asyncio
 import uuid
 from fastapi import APIRouter, Depends
 from dependencies import get_current_user, get_supabase_admin
@@ -27,11 +28,17 @@ async def create_application(
 ):
     """Adds a new job application record for tracking."""
     app_id = str(uuid.uuid4())
-    db.table("job_applications").insert({
-        "id": app_id,
-        "user_id": user["user_id"],
-        **payload.model_dump()
-    }).execute()
+    # ⚡ Bolt: Offload synchronous Supabase call to thread
+    # What: Uses asyncio.to_thread to run the synchronous .execute() call in a background thread.
+    # Why: The Supabase python client is synchronous; calling .execute() directly blocks the async event loop and increases latency.
+    # Impact: Unblocks the main thread, allowing concurrent handling of other async requests.
+    await asyncio.to_thread(
+        lambda: db.table("job_applications").insert({
+            "id": app_id,
+            "user_id": user["user_id"],
+            **payload.model_dump()
+        }).execute()
+    )
     return {"message": "Application tracked successfully.", "id": app_id}
 
 @router.get("/", response_model=List[dict])
@@ -40,8 +47,12 @@ async def list_applications(
     db=Depends(get_supabase_admin),
 ):
     """Lists all tracked applications for the current user."""
-    r = (
-        db.table("job_applications")
+    # ⚡ Bolt: Offload synchronous Supabase call to thread
+    # What: Uses asyncio.to_thread to run the synchronous .execute() call in a background thread.
+    # Why: The Supabase python client is synchronous; calling .execute() directly blocks the async event loop and increases latency.
+    # Impact: Unblocks the main thread, allowing concurrent handling of other async requests.
+    r = await asyncio.to_thread(
+        lambda: db.table("job_applications")
         .select("*")
         .eq("user_id", user["user_id"])
         .order("created_at", desc=True)
@@ -57,9 +68,15 @@ async def update_application(
     db=Depends(get_supabase_admin),
 ):
     """Updates status or notes for an application."""
-    db.table("job_applications").update(
-        payload.model_dump(exclude_none=True)
-    ).eq("id", app_id).eq("user_id", user["user_id"]).execute()
+    # ⚡ Bolt: Offload synchronous Supabase call to thread
+    # What: Uses asyncio.to_thread to run the synchronous .execute() call in a background thread.
+    # Why: The Supabase python client is synchronous; calling .execute() directly blocks the async event loop and increases latency.
+    # Impact: Unblocks the main thread, allowing concurrent handling of other async requests.
+    await asyncio.to_thread(
+        lambda: db.table("job_applications").update(
+            payload.model_dump(exclude_none=True)
+        ).eq("id", app_id).eq("user_id", user["user_id"]).execute()
+    )
     return {"message": "Application updated."}
 
 @router.delete("/{app_id}")
@@ -69,5 +86,11 @@ async def delete_application(
     db=Depends(get_supabase_admin),
 ):
     """Removes an application record."""
-    db.table("job_applications").delete().eq("id", app_id).eq("user_id", user["user_id"]).execute()
+    # ⚡ Bolt: Offload synchronous Supabase call to thread
+    # What: Uses asyncio.to_thread to run the synchronous .execute() call in a background thread.
+    # Why: The Supabase python client is synchronous; calling .execute() directly blocks the async event loop and increases latency.
+    # Impact: Unblocks the main thread, allowing concurrent handling of other async requests.
+    await asyncio.to_thread(
+        lambda: db.table("job_applications").delete().eq("id", app_id).eq("user_id", user["user_id"]).execute()
+    )
     return {"message": "Application removed."}


### PR DESCRIPTION
### 💡 What
Updated `backend/routers/applications.py` to offload synchronous Supabase `.execute()` calls to background threads using `asyncio.to_thread(lambda: ...)`.

### 🎯 Why
The Supabase python client is synchronous. Calling `.execute()` directly within FastAPI async route handlers blocks the main event loop, increasing latency and reducing concurrency.

### 📊 Impact
Unblocks the main async event loop, enabling the backend to handle concurrent requests more efficiently during database operations.

### 🔬 Measurement
Load testing or monitoring the backend should show improved throughput and reduced P99 latency under concurrent request loads.

---
*PR created automatically by Jules for task [2891745494408982724](https://jules.google.com/task/2891745494408982724) started by @SudoAnirudh*