### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Error Leakage in API Routes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** OS-level file operations (like `os.remove`) during cleanup were only catching `FileNotFoundError`. Other exceptions could propagate and leak internal paths or stack traces in 500 responses.
 **Learning:** System operations can fail for many reasons (e.g., permissions, locks). Unhandled exceptions in cleanup routines break the "fail securely" principle and risk information disclosure.
 **Prevention:** Always catch broad exceptions like `Exception` in cleanup/teardown routines, log them securely, and prevent them from propagating to the client.
+## 2024-05-28 - Information Disclosure via Exception Details
+**Vulnerability:** Broad exception handlers in backend routes were passing the raw exception string to the client (`detail=str(e)`).
+**Learning:** Exposing internal error details (such as stack traces or internal environment specifics) breaks the "fail securely" principle and provides attackers with valuable reconnaissance info.
+**Prevention:** Always log full exception details internally (e.g., using `logger.error`), but return a generic, sanitized error message to the client.

--- a/backend/routers/interview.py
+++ b/backend/routers/interview.py
@@ -390,7 +390,7 @@ async def transcribe(
         return {"text": text}
     except Exception as e:
         logger.error(f"Transcription route failure: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail="Could not process transcription.")
 
 
 @router.post("/next-question", response_model=InterviewQuestion)

--- a/backend/routers/jobs_board.py
+++ b/backend/routers/jobs_board.py
@@ -78,4 +78,5 @@ async def trigger_jobs_sync(
         new_jobs = await sync_twitter_jobs()
         return {"status": "success", "message": f"Sync complete. Added {new_jobs} jobs."}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error(f"Jobs sync route failure: {e}")
+        raise HTTPException(status_code=500, detail="Sync operation failed.")


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Unhandled exceptions or broad `except Exception` blocks were passing raw error strings directly to the client via HTTP 500 responses (`detail=str(e)`).
🎯 **Impact:** This exposes internal logic, stack traces, and potentially sensitive environment or file path information to end users, aiding attackers in reconnaissance.
🔧 **Fix:** Changed the exception handlers in `backend/routers/interview.py` and `backend/routers/jobs_board.py` to log the raw error message internally using the python logger, but raise a generic error message to the client.
✅ **Verification:** Trigger failures in the `/sync` or `/transcribe` routes and verify that the 500 status code response body only contains the sanitized generic string, not the full stack trace. All tests pass locally.

---
*PR created automatically by Jules for task [4878320239928710779](https://jules.google.com/task/4878320239928710779) started by @SudoAnirudh*